### PR TITLE
ci: fmt and tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: cargo fmt --version
+      - run: cargo fmt --all -- --check
   test:
     name: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
ci: use --workspace

cargo test/check --all is being deprecated in favor of --workspace.

ci: rename job to to test

ci: introduce cargo fmt

Despite --all being deprecated for check/test/build, it's not supported by
`cargo fmt`