### PR TITLE
nmt: switch NS convention to big-endian

### DIFF
--- a/sugondat-chain/pallets/blobs/src/lib.rs
+++ b/sugondat-chain/pallets/blobs/src/lib.rs
@@ -128,7 +128,7 @@ pub mod pallet {
             let blobs = blobs_metadata
                 .iter()
                 .map(|blob| sugondat_nmt::BlobMetadata {
-                    namespace: sugondat_nmt::Namespace::with_namespace_id(blob.namespace_id),
+                    namespace: sugondat_nmt::Namespace::from_u32_be(blob.namespace_id),
                     leaf: sugondat_nmt::NmtLeaf {
                         extrinsic_index: blob.extrinsic_index,
                         who: blob.who.encode().try_into().unwrap(),

--- a/sugondat-nmt/src/tests.rs
+++ b/sugondat-nmt/src/tests.rs
@@ -30,15 +30,15 @@ impl MockBuilder {
 #[test]
 fn two_same_blobs() {
     let mut b = MockBuilder::new();
-    b.push_blob([1u8; 32], Namespace::with_namespace_id(1), [2u8; 32]);
-    b.push_blob([1u8; 32], Namespace::with_namespace_id(1), [2u8; 32]);
+    b.push_blob([1u8; 32], Namespace::from_u32_be(1), [2u8; 32]);
+    b.push_blob([1u8; 32], Namespace::from_u32_be(1), [2u8; 32]);
     let mut tree = b.tree();
-    let proof = tree.proof(Namespace::with_namespace_id(1));
+    let proof = tree.proof(Namespace::from_u32_be(1));
     assert!(proof
         .verify(
             &[[2u8; 32], [2u8; 32]],
             tree.root(),
-            Namespace::with_namespace_id(1)
+            Namespace::from_u32_be(1)
         )
         .is_ok());
 }
@@ -46,39 +46,39 @@ fn two_same_blobs() {
 #[test]
 fn empty() {
     let mut tree = MockBuilder::new().tree();
-    let proof = tree.proof(Namespace::with_namespace_id(1));
+    let proof = tree.proof(Namespace::from_u32_be(1));
     assert!(proof
-        .verify(&[], tree.root(), Namespace::with_namespace_id(1))
+        .verify(&[], tree.root(), Namespace::from_u32_be(1))
         .is_ok());
 }
 
 #[test]
 fn empty_absent_namespace_id() {
     let mut tree = MockBuilder::new().tree();
-    let proof = tree.proof(Namespace::with_namespace_id(1));
+    let proof = tree.proof(Namespace::from_u32_be(1));
     assert!(proof
-        .verify(&[], tree.root(), Namespace::with_namespace_id(2))
+        .verify(&[], tree.root(), Namespace::from_u32_be(2))
         .is_ok());
 }
 
 #[test]
 fn proof_absent_namespace_id() {
     let mut b = MockBuilder::new();
-    b.push_blob([1u8; 32], Namespace::with_namespace_id(1), [2u8; 32]);
+    b.push_blob([1u8; 32], Namespace::from_u32_be(1), [2u8; 32]);
     let mut tree = b.tree();
-    let proof = tree.proof(Namespace::with_namespace_id(2));
+    let proof = tree.proof(Namespace::from_u32_be(2));
     assert!(proof
-        .verify(&[], tree.root(), Namespace::with_namespace_id(2))
+        .verify(&[], tree.root(), Namespace::from_u32_be(2))
         .is_ok());
 }
 
 #[test]
 fn wrong_namespace_id() {
     let mut b = MockBuilder::new();
-    b.push_blob([1u8; 32], Namespace::with_namespace_id(1), [2u8; 32]);
+    b.push_blob([1u8; 32], Namespace::from_u32_be(1), [2u8; 32]);
     let mut tree = b.tree();
-    let proof = tree.proof(Namespace::with_namespace_id(2));
+    let proof = tree.proof(Namespace::from_u32_be(2));
     assert!(proof
-        .verify(&[], tree.root(), Namespace::with_namespace_id(1))
+        .verify(&[], tree.root(), Namespace::from_u32_be(1))
         .is_err());
 }

--- a/sugondat-nmt/src/tree.rs
+++ b/sugondat-nmt/src/tree.rs
@@ -21,7 +21,7 @@ impl TreeBuilder {
     pub fn new() -> Self {
         Self {
             tree: NamespaceMerkleTree::new(),
-            last_namespace: Namespace::with_namespace_id(0),
+            last_namespace: Namespace::from_u32_be(0),
         }
     }
 

--- a/sugondat-shim/src/cli.rs
+++ b/sugondat-shim/src/cli.rs
@@ -167,8 +167,8 @@ pub mod query {
             /// The namespace to submit the blob into.
             ///
             /// The namespace can be specified either as a 4-byte vector, or as an unsigned 32-bit
-            /// integer. To distinguish between the two, the byte vector must be prefixed with
-            /// `0x`.
+            /// big-endian integer. To distinguish between the two, the byte vector must be prefixed
+            ///  with `0x`.
             #[clap(long, short, env = ENV_SUGONDAT_NAMESPACE)]
             pub namespace: String,
 

--- a/sugondat-shim/src/cmd/query/submit.rs
+++ b/sugondat-shim/src/cmd/query/submit.rs
@@ -44,7 +44,7 @@ fn read_blob(path: &str) -> anyhow::Result<Vec<u8>> {
 /// a more human-readable format, which is an unsigned 32-bit integer. To distinguish between the
 /// two, the byte vector must be prefixed with `0x`.
 ///
-/// The integer is interpreted as little-endian.
+/// The integer is interpreted as big-endian.
 fn read_namespace(namespace: &str) -> anyhow::Result<sugondat_nmt::Namespace> {
     if let Some(hex) = namespace.strip_prefix("0x") {
         let namespace = hex::decode(hex)?;
@@ -57,5 +57,5 @@ fn read_namespace(namespace: &str) -> anyhow::Result<sugondat_nmt::Namespace> {
     let namespace_id = namespace
         .parse::<u32>()
         .with_context(|| format!("cannot parse namespace id '{}'", namespace))?;
-    Ok(sugondat_nmt::Namespace::with_namespace_id(namespace_id))
+    Ok(sugondat_nmt::Namespace::from_u32_be(namespace_id))
 }

--- a/sugondat-shim/src/sugondat_rpc.rs
+++ b/sugondat-shim/src/sugondat_rpc.rs
@@ -90,7 +90,7 @@ impl Client {
         namespace: sugondat_nmt::Namespace,
         key: Keypair,
     ) -> anyhow::Result<[u8; 32]> {
-        let namespace_id = namespace.namespace_id();
+        let namespace_id = namespace.to_u32_be();
         let extrinsic = sugondat_subxt::sugondat::tx()
             .blob()
             .submit_blob(namespace_id, BoundedVec(blob));
@@ -154,7 +154,7 @@ fn extract_blobs(
         let data = submit_blob_extrinsic.blob.0;
         blobs.push(Blob {
             extrinsic_index: extrinsic_index as u32,
-            namespace: sugondat_nmt::Namespace::with_namespace_id(
+            namespace: sugondat_nmt::Namespace::from_u32_be(
                 submit_blob_extrinsic.namespace_id,
             ),
             sender,


### PR DESCRIPTION
The canonical representation of a namespace ID is [u8; N] (N=4 for now).
However, it seems to be useful at least for debugging purposes to
parse and display the namespace as an unsigned integer.

Prior this change, the integer form was defined as little-endian, just
because it's a default. Most of modern architectures are LE by default,
wasm is LE, etc. Mostly it doesn't matter, performance differences
are neglegible either way 99% of the time. I suppose the reason for
this is that LE has a marginal advantage because of the things like
that you don't need byte shuffle when reinterpreting value type (e.g.
u32 and u16) behind the same pointer and stuff like that.

However, big endian also has it's benefits. First is a human readable
representation, which is important here since this is more of a
developer convenience representation. Another, benefit is that
BE corresponds to the byte ordering. E.g., 256 > 255 (0x0100 > 0x00ff),
which doesn't hold in LE. And we do care about the ordering of
namespaces, at present because the NMT must literally be built in
order, but in future I also think it would be a useful property to
have blobs sorted.

At the same time, the performance gains of using LE are neglegible.

So given all of that I propose we change the canonical integer representation
to BE.