### PR TITLE
pallet: create SignedExtension for validating blob sizes

### DIFF
--- a/sugondat-chain/runtimes/test/src/lib.rs
+++ b/sugondat-chain/runtimes/test/src/lib.rs
@@ -90,6 +90,7 @@ pub type SignedExtra = (
     frame_system::CheckNonce<Runtime>,
     frame_system::CheckWeight<Runtime>,
     pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+    pallet_sugondat_blobs::PrevalidateBlobs,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.

--- a/sugondat-shim/src/dock/mod.rs
+++ b/sugondat-shim/src/dock/mod.rs
@@ -7,8 +7,8 @@ use subxt_signer::sr25519::Keypair;
 use crate::sugondat_rpc;
 
 mod rollkit;
-mod sovereign;
 mod rpc_error;
+mod sovereign;
 
 /// A configuration for initializing all docks.
 pub struct Config {


### PR DESCRIPTION
This partially addresses #74 with a cleaner solution making use of the `SignedExtension` trait. This requires a one-line change in the runtime. I say partially addresses, because it currently lacks tests, and it is not a part of the Kusama runtime introduced in #75 .

If my understanding of the implementation of `frame_executive` and the docs on `SignedExtension` are correct, it behaves like this:
  1. During transaction validation for the mempool, only `fn validate` is called. This is our opportunity to signal that the size is too large to honest nodes.
  2. During block authorship, `fn pre_dispatch` is called prior to dispatching. This is our opportunity to signal to the block author that the transaction exhausts resources and should be skipped. (see polkadot-sdk `basic_authorship` for implementation details)
  3. As such, only blocks authored by malicious nodes will dispatch `submit_blob` calls with blobs beyond those limits, and therefore we panic during dispatch.