### PR TITLE
chore: fix blobs tests

### DIFF
--- a/sugondat-chain/pallets/blobs/src/mock.rs
+++ b/sugondat-chain/pallets/blobs/src/mock.rs
@@ -52,9 +52,9 @@ impl frame_system::Config for Test {
 
 impl pallet_blobs::Config for Test {
     type RuntimeEvent = RuntimeEvent;
-    type MaxBlobs = ConstU32<{ 100 * 1024 }>;
-    type MaxBlobSize = ConstU32<{ 100 * 1024 }>;
-    type MaxTotalBlobSize = ConstU32<{ 2 * 1024 * 1024 }>;
+    type MaxBlobs = ConstU32<16>;
+    type MaxBlobSize = ConstU32<1024>;
+    type MaxTotalBlobSize = ConstU32<{ 10 * 1024 }>;
     type WeightInfo = ();
 }
 

--- a/sugondat-chain/pallets/blobs/src/tests.rs
+++ b/sugondat-chain/pallets/blobs/src/tests.rs
@@ -70,15 +70,30 @@ fn test_max_blobs_reached() {
                 blob.clone()
             ));
         }
-        assert_noop!(
-            Blobs::submit_blob(RuntimeOrigin::signed(alice()), 0, blob.clone()),
-            Error::<Test>::MaxBlobsReached
-        );
     });
 }
 
 #[test]
-fn test_max_total_blob_size() {
+#[should_panic = "Maximum blob limit exceeded"]
+fn test_max_blobs_exceeded() {
+    let max_blobs: u32 = <Test as pallet_blobs::Config>::MaxBlobs::get();
+
+    new_test_ext().execute_with(|| {
+        let blob = get_blob(1);
+        for i in 0..max_blobs {
+            assert_ok!(Blobs::submit_blob(
+                RuntimeOrigin::signed(alice()),
+                i,
+                blob.clone()
+            ));
+        }
+
+        let _ = Blobs::submit_blob(RuntimeOrigin::signed(alice()), 0, blob.clone());
+    });
+}
+
+#[test]
+fn test_max_total_blob_size_reached() {
     let max_total_blobs_size: u32 = <Test as pallet_blobs::Config>::MaxTotalBlobSize::get();
     let max_blob_size: u32 = <Test as pallet_blobs::Config>::MaxBlobSize::get();
     let blobs_needed = max_total_blobs_size / max_blob_size;
@@ -92,10 +107,26 @@ fn test_max_total_blob_size() {
                 blob.clone()
             ));
         }
-        assert_noop!(
-            Blobs::submit_blob(RuntimeOrigin::signed(alice()), 0, blob.clone()),
-            Error::<Test>::MaxTotalBlobsSizeReached
-        );
+    });
+}
+
+#[test]
+#[should_panic = "Maximum total blob size exceeded"]
+fn test_max_total_blob_size_exceeded() {
+    let max_total_blobs_size: u32 = <Test as pallet_blobs::Config>::MaxTotalBlobSize::get();
+    let max_blob_size: u32 = <Test as pallet_blobs::Config>::MaxBlobSize::get();
+    let blobs_needed = max_total_blobs_size / max_blob_size;
+
+    new_test_ext().execute_with(|| {
+        let blob = get_blob(max_blob_size);
+        for i in 0..blobs_needed {
+            assert_ok!(Blobs::submit_blob(
+                RuntimeOrigin::signed(alice()),
+                i,
+                blob.clone()
+            ));
+        }
+        let _ = Blobs::submit_blob(RuntimeOrigin::signed(alice()), 0, blob.clone());
     });
 }
 


### PR DESCRIPTION
closes #91 

This takes the constants down significantly too, because the tests take a long time to run.

I have added tests for reaching the limits exactly, as well as `#[should_panic]` tests where we overrun them.