### PR TITLE
Use 16 byte namespaces, introduce wrapper type for pallet parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,6 +3338,16 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
@@ -3538,7 +3548,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84f2e425d9790201ba4af4630191feac6dcc98765b118d4d18e91d23c2353866"
 dependencies = [
- "env_logger",
+ "env_logger 0.10.1",
  "log",
 ]
 
@@ -7580,6 +7590,8 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
+ "quickcheck",
+ "quickcheck_macros",
  "scale-info",
  "serde",
  "sha2 0.10.8",
@@ -9560,6 +9572,28 @@ dependencies = [
  "quick-protobuf",
  "thiserror",
  "unsigned-varint",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger 0.8.4",
+ "log",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -13857,6 +13891,7 @@ dependencies = [
 name = "sugondat-primitives"
 version = "0.1.0"
 dependencies = [
+ "parity-scale-codec",
  "sp-consensus-aura",
  "sp-core",
  "sp-runtime",

--- a/sugondat-chain/pallets/blobs/Cargo.toml
+++ b/sugondat-chain/pallets/blobs/Cargo.toml
@@ -29,10 +29,12 @@ sugondat-nmt = { path = "../../../sugondat-nmt", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.132" }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0"}
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
 
 # Substrate
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0"}
 
 [features]
 default = ["std"]

--- a/sugondat-chain/pallets/blobs/src/namespace_param.rs
+++ b/sugondat-chain/pallets/blobs/src/namespace_param.rs
@@ -1,0 +1,99 @@
+//! Namespaces as a parameter.
+//!
+//! Namespaces are encoded as 16-byte arrays, with the following schema:
+//!   - The first byte is reserved for a version byte which determines the format
+//!     of the following 15 bytes. At the moment, the only supported value for this byte
+//!     is `0x00`, which indicates version 0.
+//!   - In version 0, bytes 1 through 5 are required to be equal to `0x00` and bytes 6 through
+//!     15 are allowed to hold any value.
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_runtime::RuntimeDebug;
+
+/// An error in namespace validation.
+pub enum NamespaceValidationError {
+    /// Unrecognized version.
+    UnrecognizedVersion(u8),
+    /// V0: reserved bytes are non-zero.
+    V0NonZeroReserved,
+}
+
+/// Validate a namespace against known schemas.
+pub fn validate(namespace: &[u8; 16]) -> Result<(), NamespaceValidationError> {
+    if namespace[0] != 0 {
+        return Err(NamespaceValidationError::UnrecognizedVersion(namespace[0]));
+    }
+    if &namespace[1..6] != &[0, 0, 0, 0, 0] {
+        return Err(NamespaceValidationError::V0NonZeroReserved);
+    }
+
+    Ok(())
+}
+
+/// Type-safe wrapper around an unvalidated blob namespace.
+#[derive(Encode, Decode, TypeInfo, MaxEncodedLen, Clone, PartialEq, RuntimeDebug)]
+pub struct UnvalidatedNamespace([u8; 16]);
+
+impl UnvalidatedNamespace {
+    /// Validate the namespace, extracting the full data.
+    pub fn validate(&self) -> Result<u128, NamespaceValidationError> {
+        validate(&self.0).map(|()| u128::from_be_bytes(self.0))
+    }
+}
+
+impl From<[u8; 16]> for UnvalidatedNamespace {
+    fn from(x: [u8; 16]) -> Self {
+        UnvalidatedNamespace(x)
+    }
+}
+
+impl From<u128> for UnvalidatedNamespace {
+    fn from(x: u128) -> Self {
+        UnvalidatedNamespace(x.to_be_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::TestResult;
+    use quickcheck_macros::quickcheck;
+    use std::matches;
+
+    #[quickcheck]
+    fn namespace_validation_not_v0_fails(version_byte: u8) -> TestResult {
+        if version_byte == 0x00 {
+            return TestResult::discard();
+        }
+        TestResult::from_bool(matches!(
+            validate(&[version_byte, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            Err(NamespaceValidationError::UnrecognizedVersion(v)) if v == version_byte,
+        ))
+    }
+
+    #[quickcheck]
+    fn namespace_validation_v0_reserved_occupied_fails(
+        reserved: (u8, u8, u8, u8, u8),
+    ) -> TestResult {
+        if reserved == (0, 0, 0, 0, 0) {
+            return TestResult::discard();
+        }
+        let (a, b, c, d, e) = reserved;
+        TestResult::from_bool(matches!(
+            validate(&[0u8, a, b, c, d, e, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            Err(NamespaceValidationError::V0NonZeroReserved),
+        ))
+    }
+
+    #[quickcheck]
+    fn namespace_validation_v0_works(namespace: Vec<u8>) -> TestResult {
+        if namespace.len() < 10 {
+            return TestResult::discard();
+        }
+
+        let mut n = [0u8; 16];
+        n[6..].copy_from_slice(&namespace[..10]);
+        TestResult::from_bool(matches!(validate(&n), Ok(())))
+    }
+}

--- a/sugondat-chain/primitives/Cargo.toml
+++ b/sugondat-chain/primitives/Cargo.toml
@@ -7,10 +7,12 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
+
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
 sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
 
 [features]
 default = ["std"]
-std = ["sp-runtime/std", "sp-core/std", "sp-consensus-aura/std"]
+std = ["codec/std", "sp-runtime/std", "sp-core/std", "sp-consensus-aura/std"]

--- a/sugondat-chain/primitives/src/lib.rs
+++ b/sugondat-chain/primitives/src/lib.rs
@@ -50,4 +50,6 @@ pub mod opaque {
 pub enum InvalidTransactionCustomError {
     /// The blob exceeds the configured per-blob size limit.
     BlobExceedsSizeLimit = 100,
+    /// The namespace ID is invalid.
+    InvalidNamespaceId = 101,
 }

--- a/sugondat-nmt/src/lib.rs
+++ b/sugondat-nmt/src/lib.rs
@@ -4,7 +4,7 @@
 
 extern crate alloc;
 
-pub const NS_ID_SIZE: usize = 4;
+pub const NS_ID_SIZE: usize = 16;
 
 mod blob_metadata;
 mod leaf;

--- a/sugondat-nmt/src/ns.rs
+++ b/sugondat-nmt/src/ns.rs
@@ -3,15 +3,15 @@ use core::fmt;
 
 /// Namespace identifier type.
 ///
-/// Blobs are submitted into a namespace. Namepsace is a 4 byte vector. Namespaces define ordering
+/// Blobs are submitted into a namespace. Namespace is a 16 byte vector. Namespaces define ordering
 /// lexicographically.
 ///
-/// For convenience, a namespace can be created from an unsigned 32-bit integer. Conventionally,
+/// For convenience, a namespace can be created from an unsigned 128-bit integer. Conventionally,
 /// big-endian representation of the integer is used as that is more intuitive. As one may expect:
 ///
 /// ```
 /// # use sugondat_nmt::Namespace;
-/// assert!(Namespace::from_u32_be(0x0100) > Namespace::from_u32_be(0x00FF));
+/// assert!(Namespace::from_u128_be(0x0100) > Namespace::from_u128_be(0x00FF));
 /// ````
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -32,13 +32,13 @@ impl Namespace {
     ///
     /// This function will take the given integer (which is assumed to be in host byte order), and
     /// take its big-endian representation as the namespace ID.
-    pub fn from_u32_be(namespace_id: u32) -> Self {
+    pub fn from_u128_be(namespace_id: u128) -> Self {
         Self(namespace_id.to_be_bytes())
     }
 
     /// Reinterpret the namespace ID as a big-endian 32-bit integer and return.
-    pub fn to_u32_be(&self) -> u32 {
-        u32::from_be_bytes(self.0)
+    pub fn to_u128_be(&self) -> u128 {
+        u128::from_be_bytes(self.0)
     }
 
     pub(crate) fn with_nmt_namespace_id(nmt_namespace_id: nmt_rs::NamespaceId<NS_ID_SIZE>) -> Self {

--- a/sugondat-nmt/src/root.rs
+++ b/sugondat-nmt/src/root.rs
@@ -13,8 +13,8 @@ impl TreeRoot {
         let mut root = [0u8; 32];
         root.copy_from_slice(&raw[0..32]);
 
-        let min_ns = Namespace::from_raw_bytes(raw[32..36].try_into().unwrap());
-        let max_ns = Namespace::from_raw_bytes(raw[36..40].try_into().unwrap());
+        let min_ns = Namespace::from_raw_bytes(raw[32..48].try_into().unwrap());
+        let max_ns = Namespace::from_raw_bytes(raw[48..64].try_into().unwrap());
 
         Self {
             root,
@@ -26,8 +26,8 @@ impl TreeRoot {
     pub fn to_raw_bytes(&self) -> [u8; 68] {
         let mut raw = [0u8; 68];
         raw[0..32].copy_from_slice(&self.root);
-        raw[32..36].copy_from_slice(&self.min_ns.to_raw_bytes());
-        raw[36..40].copy_from_slice(&self.max_ns.to_raw_bytes());
+        raw[32..48].copy_from_slice(&self.min_ns.to_raw_bytes());
+        raw[48..64].copy_from_slice(&self.max_ns.to_raw_bytes());
         raw
     }
 }

--- a/sugondat-nmt/src/tests.rs
+++ b/sugondat-nmt/src/tests.rs
@@ -30,15 +30,15 @@ impl MockBuilder {
 #[test]
 fn two_same_blobs() {
     let mut b = MockBuilder::new();
-    b.push_blob([1u8; 32], Namespace::from_u32_be(1), [2u8; 32]);
-    b.push_blob([1u8; 32], Namespace::from_u32_be(1), [2u8; 32]);
+    b.push_blob([1u8; 32], Namespace::from_u128_be(1), [2u8; 32]);
+    b.push_blob([1u8; 32], Namespace::from_u128_be(1), [2u8; 32]);
     let mut tree = b.tree();
-    let proof = tree.proof(Namespace::from_u32_be(1));
+    let proof = tree.proof(Namespace::from_u128_be(1));
     assert!(proof
         .verify(
             &[[2u8; 32], [2u8; 32]],
             tree.root(),
-            Namespace::from_u32_be(1)
+            Namespace::from_u128_be(1)
         )
         .is_ok());
 }
@@ -46,39 +46,39 @@ fn two_same_blobs() {
 #[test]
 fn empty() {
     let mut tree = MockBuilder::new().tree();
-    let proof = tree.proof(Namespace::from_u32_be(1));
+    let proof = tree.proof(Namespace::from_u128_be(1));
     assert!(proof
-        .verify(&[], tree.root(), Namespace::from_u32_be(1))
+        .verify(&[], tree.root(), Namespace::from_u128_be(1))
         .is_ok());
 }
 
 #[test]
 fn empty_absent_namespace_id() {
     let mut tree = MockBuilder::new().tree();
-    let proof = tree.proof(Namespace::from_u32_be(1));
+    let proof = tree.proof(Namespace::from_u128_be(1));
     assert!(proof
-        .verify(&[], tree.root(), Namespace::from_u32_be(2))
+        .verify(&[], tree.root(), Namespace::from_u128_be(2))
         .is_ok());
 }
 
 #[test]
 fn proof_absent_namespace_id() {
     let mut b = MockBuilder::new();
-    b.push_blob([1u8; 32], Namespace::from_u32_be(1), [2u8; 32]);
+    b.push_blob([1u8; 32], Namespace::from_u128_be(1), [2u8; 32]);
     let mut tree = b.tree();
-    let proof = tree.proof(Namespace::from_u32_be(2));
+    let proof = tree.proof(Namespace::from_u128_be(2));
     assert!(proof
-        .verify(&[], tree.root(), Namespace::from_u32_be(2))
+        .verify(&[], tree.root(), Namespace::from_u128_be(2))
         .is_ok());
 }
 
 #[test]
 fn wrong_namespace_id() {
     let mut b = MockBuilder::new();
-    b.push_blob([1u8; 32], Namespace::from_u32_be(1), [2u8; 32]);
+    b.push_blob([1u8; 32], Namespace::from_u128_be(1), [2u8; 32]);
     let mut tree = b.tree();
-    let proof = tree.proof(Namespace::from_u32_be(2));
+    let proof = tree.proof(Namespace::from_u128_be(2));
     assert!(proof
-        .verify(&[], tree.root(), Namespace::from_u32_be(1))
+        .verify(&[], tree.root(), Namespace::from_u128_be(1))
         .is_err());
 }

--- a/sugondat-nmt/src/tree.rs
+++ b/sugondat-nmt/src/tree.rs
@@ -21,7 +21,7 @@ impl TreeBuilder {
     pub fn new() -> Self {
         Self {
             tree: NamespaceMerkleTree::new(),
-            last_namespace: Namespace::from_u32_be(0),
+            last_namespace: Namespace::from_u128_be(0),
         }
     }
 


### PR DESCRIPTION
Also updates the transaction validation logic to reject transactions with invalid namespaces.

Closes #12 