### PR TITLE
Switching to self-hosted runner.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,31 @@ env:
 jobs:
   build_and_test:
     name: Sugondat - latest
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       matrix:
         toolchain:
           - stable
     steps:
       - uses: actions/checkout@v3
-      - run: sudo apt-get install protobuf-compiler
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: rustup target add wasm32-unknown-unknown
-      - run: rustup install nightly && rustup target add wasm32-unknown-unknown --toolchain nightly
-      - run: cargo build --verbose --all
-      - run: cargo test --verbose --all
+      - run: apt-get update
+      - run: apt-get install -y protobuf-compiler
+      - run: apt-get install -y build-essential
+      - run: apt-get install -y libclang-dev
+      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
+      - name: Setup toolchain
+        run: |
+          source "$HOME/.cargo/env"
+          rustup update ${{ matrix.toolchain }}
+          rustup default ${{ matrix.toolchain }}
+          rustup target add wasm32-unknown-unknown
+          rustup install nightly
+          rustup target add wasm32-unknown-unknown --toolchain nightly
+      - name: cargo build
+        run: |
+          source "$HOME/.cargo/env"
+          cargo build --verbose --all
+      - name: cargo test
+        run: |
+          source "$HOME/.cargo/env"
+          cargo test --verbose --all


### PR DESCRIPTION
Related #120 

The build will initially fail. It's necessary to register a self-hosted runner in the repo settings first as described here: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners#adding-a-self-hosted-runner-to-a-repository