### PR TITLE
shim: update the wrong version message

### DIFF
--- a/sugondat-shim/src/sugondat_rpc/conn.rs
+++ b/sugondat-shim/src/sugondat_rpc/conn.rs
@@ -25,7 +25,7 @@ impl Conn {
         check_if_compatible(&subxt)?;
         if !is_codegen_valid_for(&subxt.metadata()) {
             const WARN_WRONG_VERSION: &str = "connected to a sugondat node with a newer runtime than the one this shim was compiled against. Update the shim lest you run into problems. https://github.com/thrumdev/blobs";
-            tracing::warn!(WARN_WRONG_VERSION);
+            tracing::warn!("{}", WARN_WRONG_VERSION);
         }
         let finalized = FinalizedHeadWatcher::spawn(subxt.clone()).await;
         Ok(Arc::new(Self {


### PR DESCRIPTION
without this, the message would say

WARN_WRONG_VERSION="connected to a sugondat node with a newer runtime than the one this shim was compiled against. Update the shim lest you run into problems. https://github.com/thrumdev/sugondat"