### PR TITLE
chore: fix instruction for reseting state of gm

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,5 +130,5 @@ To reset the chain
 ```sh
 rm -r zombienet
 cd demo/rollkit
-gmd unsafe-reset-all
+gmd tendermint unsafe-reset-all
 ```


### PR DESCRIPTION
During testing I realized that the instruction for reseting chain state is incorrect. This change fixes it.
