### PR TITLE
ci: use gha-runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: build-test-linux-stable
+name: ci
 
 on:
   push:
@@ -23,30 +23,9 @@ jobs:
   build_and_test:
     name: Sugondat - latest
     runs-on: self-hosted
-    strategy:
-      matrix:
-        toolchain:
-          - stable
     steps:
       - uses: actions/checkout@v3
-      - run: apt-get update
-      - run: apt-get install -y protobuf-compiler
-      - run: apt-get install -y build-essential
-      - run: apt-get install -y libclang-dev
-      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
-      - name: Setup toolchain
-        run: |
-          source "$HOME/.cargo/env"
-          rustup update ${{ matrix.toolchain }}
-          rustup default ${{ matrix.toolchain }}
-          rustup target add wasm32-unknown-unknown
-          rustup install nightly
-          rustup target add wasm32-unknown-unknown --toolchain nightly
       - name: cargo build
-        run: |
-          source "$HOME/.cargo/env"
-          cargo build --verbose --all
+        run: cargo build --verbose --all
       - name: cargo test
-        run: |
-          source "$HOME/.cargo/env"
-          cargo test --verbose --all
+        run: cargo test --verbose --all

--- a/docker/gha-runner.Dockerfile
+++ b/docker/gha-runner.Dockerfile
@@ -1,0 +1,44 @@
+# An image that acts as the base image for the GHA runner running in sysbox.
+#
+# Build: docker build -t ghcr.io/thrumdev/gha-runner -f docker/gha-runner.Dockerfile .
+# Push: docker push ghcr.io/thrumdev/gha-runner
+
+FROM rodnymolina588/gha-sysbox-runner@sha256:d10a36f2da30aa0df71d1ac062cc79fc5114eec7b6ae8a0c42cadf568e6eefa8
+
+ARG RUSTC_VERSION=nightly-2023-10-16
+
+LABEL org.opencontainers.image.source=https://github.com/thrumdev/blobs
+
+ENV CARGO_INCREMENTAL=0
+ENV CARGO_HOME=/cargo
+ENV CARGO_TARGET_DIR=/cargo_target
+ENV RUSTFLAGS=""
+ENV RUSTUP_HOME=/rustup
+
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        protobuf-compiler \
+        curl \
+        git \
+        llvm \
+        clang \
+        cmake \
+        make \
+        libssl-dev \
+        pkg-config
+
+RUN \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain $RUSTC_VERSION
+ENV PATH=$CARGO_HOME/bin:$PATH
+
+RUN rustup target add wasm32-unknown-unknown
+
+# Install cargo binstall, using it install cargo-risczero, and using it install risc0 toolchain.
+RUN curl \
+    -L --proto '=https' --tlsv1.2 -sSf \
+    https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
+    | bash
+RUN cargo binstall --no-confirm --no-symlinks cargo-risczero
+RUN cargo risczero install


### PR DESCRIPTION
Customize the docker image for use on the self-hosted GHA runner.

This allows us to elide installation steps from the CI workflow and
enables us using a shared cache for builds.