### PR TITLE
build: remove rococo-native from the build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9104,7 +9104,6 @@ dependencies = [
  "polkadot-runtime-parachains",
  "polkadot-statement-distribution",
  "rococo-runtime",
- "rococo-runtime-constants",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-block-builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,13 @@
+[profile.release]
+panic = "unwind"
+incremental = true
+debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
+
+[profile.dev]
+# Disabling debug info speeds up builds a bunch,
+# and we don't rely on it for debugging that much.
+debug = 0
+
 [workspace]
 resolver = "2"
 members = [
@@ -13,6 +23,3 @@ members = [
     "sugondat-shim/common/sovereign",
     "sugondat-subxt"
 ]
-
-[profile.release]
-panic = "unwind"

--- a/sugondat-chain/node/Cargo.toml
+++ b/sugondat-chain/node/Cargo.toml
@@ -59,7 +59,7 @@ substrate-prometheus-endpoint = { git = "https://github.com/paritytech/polkadot-
 try-runtime-cli = { git = "https://github.com/paritytech/polkadot-sdk", optional = true , branch = "release-polkadot-v1.4.0" }
 
 # Polkadot
-polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", features = ["rococo-native"] , branch = "release-polkadot-v1.4.0" }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.4.0" }
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.4.0" }
 xcm = { package = "staging-xcm", git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
 


### PR DESCRIPTION
Closes #139

I've verified that rococo-runtime is not built. However, rococo-runtime-constants
are still built. Running `cargo tree` confirms the observation, `rococo-runtime` is
not in tree and `rococo-runtime-constants` is.

The changes of Cargo.lock are a bit confusing though, because it's actually the opposite:
-constants is removed and rococo-runtime still is present.

I've also verified that the sovereign demo works.