### PR TITLE
Blobs Fee Adjustment

### DIFF
--- a/sugondat-chain/pallets/blobs/Cargo.toml
+++ b/sugondat-chain/pallets/blobs/Cargo.toml
@@ -20,7 +20,7 @@ frame-support = { git = "https://github.com/paritytech/polkadot-sdk", default-fe
 frame-system = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
 sp-std = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0", optional = true}
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0"}
 
 # Local
 sugondat-primitives = { path = "../../primitives", default-features = false }
@@ -34,7 +34,6 @@ quickcheck_macros = "1.0.0"
 
 # Substrate
 sp-core = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0"}
 sp-state-machine = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0"}
 sp-trie = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0"}
 
@@ -45,7 +44,6 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
-	"dep:sp-io"
 ]
 std = [
 	"codec/std",
@@ -54,6 +52,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"sp-std/std",
+	"sp-io/std",
 	"sugondat-nmt/native",
     "sugondat-primitives/std",
 ]

--- a/sugondat-chain/pallets/blobs/src/lib.rs
+++ b/sugondat-chain/pallets/blobs/src/lib.rs
@@ -227,6 +227,23 @@ pub mod pallet {
             });
             Ok(().into())
         }
+
+        #[pallet::call_index(1)]
+        #[pallet::weight(0)]
+        pub fn update_parameter(
+            origin: OriginFor<T>,
+            parameter: Vec<u8>,
+            // already encoded value
+            value: Vec<u8>,
+        ) -> DispatchResultWithPostInfo {
+            let who = ensure_root(origin)?;
+            let key = match (parameter.first(), parameter.last()) {
+                (Some(b':'), Some(b':')) => parameter,
+                _ => [vec![b':'], parameter, vec![b':']].concat(),
+            };
+            sp_io::storage::set(&key, &value);
+            Ok(().into())
+        }
     }
 
     fn sha2_hash(data: &[u8]) -> [u8; 32] {

--- a/sugondat-chain/primitives/src/lib.rs
+++ b/sugondat-chain/primitives/src/lib.rs
@@ -5,6 +5,8 @@ use sp_runtime::{
     MultiSignature,
 };
 
+pub const MAX_BLOCK_LENGTH: u32 = 5 * 1024 * 1024;
+
 /// An index to a block.
 pub type BlockNumber = u32;
 

--- a/sugondat-chain/runtimes/sugondat-kusama/Cargo.toml
+++ b/sugondat-chain/runtimes/sugondat-kusama/Cargo.toml
@@ -53,6 +53,7 @@ sp-session = { git = "https://github.com/paritytech/polkadot-sdk", default-featu
 sp-std = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
 sp-transaction-pool = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
 sp-version = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0"}
 
 # Polkadot
 pallet-xcm = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0" }
@@ -78,7 +79,6 @@ parachain-info = { package = "staging-parachain-info", git = "https://github.com
 parachains-common = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.4.0", default-features = false }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0"}
 sp-tracing = { git = "https://github.com/paritytech/polkadot-sdk", default-features = false, branch = "release-polkadot-v1.4.0"}
 
 [features]

--- a/sugondat-chain/runtimes/sugondat-kusama/src/constants.rs
+++ b/sugondat-chain/runtimes/sugondat-kusama/src/constants.rs
@@ -25,6 +25,7 @@ pub mod consensus {
     // Time is measured by number of blocks.
     pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
     pub const HOURS: BlockNumber = MINUTES * 60;
+    pub const DAYS: BlockNumber = HOURS * 24;
 
     /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
     /// used to limit the maximal weight of a single extrinsic.


### PR DESCRIPTION
This is an extremely experimental implementation, not ready for technical review but rather an example of a possible implementation.

The goal here was to test an approach to fitting `TargetedFeeAdjustment` to our needs.

What I have done is create a connection between a `TargetBlockFullness` in bytes and a `TargetBlockFullness` in ref_time.

The main problem is that there is no easy connection between these two variables. One way I have figured out to deal with this is:

- Simplify the weight of a `submit_blob` extrinsic into two parts: `base_weight` (referring to all the extrinsic actions unrelated to the blob of bytes) and `byte_weight` (the weight attached to each byte of the blob, which mainly depends on the hash function). The resulting formula for the weight is: `base_weight + blob.len() * byte_weight`.
- Each block could contain a different quantity of submitted blobs, and the size of these blobs can easily change over time. However, there is no way (as far as I know) to predict how the `ref_time` will be composed, whether there will be more extrinsic with little blobs or fewer extrinsic with giant blobs. 
    - My solution to this problem is to average this factor at each block and use the result to evaluate the cost of traffic for the next block.
- Some test logic to increase the `TargetBlockSize` if blocks were full more than expected.

The final formulas are:

`min_ext_len` = size in bytes of an empty `submit_blob` extrinsic

`average_blob_size` = `TotalBlobSize / TotalBlobs`

`average_submit_blob_weight` = weight of a `submit_blob` extrinsic with a blob the size of `average_blob_size`

`target_ref_time` = (`TargetBlockSize / (min_ext_len + average_blob_size)) * average_submit_blob_weight`

`TargetBlockFullness` = `target_ref_time / max_available_ref_time`

Final thoughts:
I may not have considered some factors, and there may be different approaches that could be used rather than sticking solely to `TargetedFeeAdjustment`.
I am open to suggestions and criticism!

