### PR TITLE
shim: implement block query

### DIFF
--- a/sugondat/shim/src/cmd/query/block.rs
+++ b/sugondat/shim/src/cmd/query/block.rs
@@ -1,0 +1,43 @@
+use super::connect_rpc;
+use crate::cli::query::block::{BlockRef, Params};
+
+pub async fn run(params: Params) -> anyhow::Result<()> {
+    let Params { rpc, block } = params;
+
+    let client = connect_rpc(rpc).await?;
+
+    let maybe_hash = match block {
+        BlockRef::Best => None,
+        BlockRef::Hash(h) => Some(h),
+        BlockRef::Number(n) => Some(
+            client
+                .block_hash(n)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("No block with number {}", n))?
+                .0,
+        ),
+    };
+
+    let block = client.get_block_at(maybe_hash).await?;
+
+    println!("Block: #{}", block.number);
+    println!("  Hash: 0x{}", hex::encode(&block.hash[..]));
+    println!("  Parent Hash: 0x{}", hex::encode(&block.parent_hash[..]));
+    println!("  Blobs Root: 0x{}", hex::encode(&block.tree_root.root[..]));
+    println!("  Min Namespace: {}", block.tree_root.min_ns);
+    println!("  Max Namespace: {}", block.tree_root.max_ns);
+    println!("  Timestamp: {}", block.timestamp);
+    println!(
+        "  Blob Count: {} ({} bytes)",
+        block.blobs.len(),
+        block.blobs.iter().map(|b| b.data.len()).sum::<usize>(),
+    );
+    for (i, blob) in block.blobs.into_iter().enumerate() {
+        println!(" Blob #{}", i + 1);
+        println!("    Extrinsic Index: {}", blob.extrinsic_index);
+        println!("    Namespace: {}", &blob.namespace);
+        println!("    Size: {}", blob.data.len());
+    }
+
+    Ok(())
+}

--- a/sugondat/shim/src/cmd/query/mod.rs
+++ b/sugondat/shim/src/cmd/query/mod.rs
@@ -3,11 +3,13 @@ use crate::{
     sugondat_rpc,
 };
 
+mod block;
 mod submit;
 
 pub async fn run(params: Params) -> anyhow::Result<()> {
     match params.command {
         Commands::Submit(params) => submit::run(params).await?,
+        Commands::Block(params) => block::run(params).await?,
     }
     Ok(())
 }

--- a/sugondat/shim/src/dock/rollkit.rs
+++ b/sugondat/shim/src/dock/rollkit.rs
@@ -34,7 +34,7 @@ impl RollkitRPCServer for RollkitDock {
         );
         let namespace = parse_namespace(&namespace).map_err(|_| err::bad_namespace())?;
         let block_hash = self.client.wait_finalized_height(height).await;
-        let block = self.client.get_block_at(block_hash).await.unwrap();
+        let block = self.client.get_block_at(Some(block_hash)).await.unwrap();
         let mut blobs = vec![];
         for blob in block.blobs {
             if blob.namespace == namespace {

--- a/sugondat/shim/src/dock/sovereign.rs
+++ b/sugondat/shim/src/dock/sovereign.rs
@@ -34,7 +34,7 @@ impl SovereignRPCServer for SovereignDock {
     ) -> Result<Block, ErrorObjectOwned> {
         info!("get_block({})", height);
         let block_hash = self.client.wait_finalized_height(height).await;
-        let block = self.client.get_block_at(block_hash).await.unwrap();
+        let block = self.client.get_block_at(Some(block_hash)).await.unwrap();
         let proof = make_namespace_proof(&block, namespace);
         let blobs = block
             .blobs


### PR DESCRIPTION
This implements the `shim query block` subcommand. The behavior is to default to the best block, but users may query blocks by number or hash as well.

Sample output:

```
Block: #128420
  Hash: 0xc5bbe678bd4b25fa15d5828610627177c36288c5cfa18b76f1bfae1176c2974b
  Parent Hash: 0x46b1dbf80b848aa8c8ff1059c1d02fd0b209eac2756bdfacc70c9984a607e92e
  Blobs Root: 0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
  Min Namespace: 0x00000000000000000000000000000000
  Max Namespace: 0x00000000000000000000000000000000
  Timestamp: 1703806386000
  Blob Count: 0 (0 bytes)
```

I would appreciate it if we didn't review the output format too harshly in this PR, and instead adjust that in follow-ups.