### PR TITLE
shim: print zero-based blob indices

### DIFF
--- a/sugondat/shim/src/cmd/query/blob.rs
+++ b/sugondat/shim/src/cmd/query/blob.rs
@@ -39,7 +39,7 @@ pub async fn run(params: Params) -> anyhow::Result<()> {
     } else {
         println!(
             " Blob #{}, Namespace {}, {} bytes",
-            i + 1,
+            i,
             &blob.namespace,
             blob.data.len()
         );

--- a/sugondat/shim/src/cmd/query/block.rs
+++ b/sugondat/shim/src/cmd/query/block.rs
@@ -33,7 +33,7 @@ pub async fn run(params: Params) -> anyhow::Result<()> {
         block.blobs.iter().map(|b| b.data.len()).sum::<usize>(),
     );
     for (i, blob) in block.blobs.into_iter().enumerate() {
-        println!(" Blob #{}", i + 1);
+        println!(" Blob #{}", i);
         println!("    Extrinsic Index: {}", blob.extrinsic_index);
         println!("    Namespace: {}", &blob.namespace);
         println!("    Size: {}", blob.data.len());


### PR DESCRIPTION
I initially felt that the 1-based indices were more human friendly, but it does conflict with the extrinsic indices being 0-based. Probably, the users are familiar enough with computers that 0-based indices will not be too confusing. For consistency with other index types, a 0-based index is preferable to me.