### PR TITLE
shim/cli: clarification on behavior

### DIFF
--- a/sugondat/shim/src/cli.rs
+++ b/sugondat/shim/src/cli.rs
@@ -147,6 +147,8 @@ pub mod query {
         /// Submits the given blob into a namespace.
         Submit(submit::Params),
         /// Queries information about a block and header.
+        ///
+        /// Returns an error if the given block is not available.
         Block(block::Params),
         /// Queries information about a specific blob.
         Blob(blob::Params),


### PR DESCRIPTION
This is a follow up for #164 that clarifies the status quo behavior
when the block is not available in the CLI docs.