### PR TITLE
node: author the first block unconditionally

### DIFF
--- a/sugondat/chain/node/src/proposer.rs
+++ b/sugondat/chain/node/src/proposer.rs
@@ -5,6 +5,7 @@
 //!    non-inherent extrinsics and avoid authoring empty blocks.
 //! 2. There is an incoming downward message from the relay chain.
 //! 3. There is a go-ahead signal for a parachain code upgrade.
+//! 4. The block is the first block of the parachain. Useful for testing.
 //!
 //! If any of these conditions are met, then the block is authored.
 
@@ -83,8 +84,13 @@ impl<P: ProposerInterface<Block> + Send> ProposerInterface<Block> for BlockLimit
                 Ok(None) => false,
             }
         };
+        let first_block = {
+            // allow creating the first block without the above conditions. This is useful for
+            // testing for detection of healthiness.
+            parent_header.number == 0
+        };
 
-        if has_downward_message || has_go_ahead || has_transactions {
+        if has_downward_message || has_go_ahead || has_transactions || first_block {
             self.inner
                 .propose(
                     parent_header,


### PR DESCRIPTION
This behavior is useful for testing. Specifically, for simple detection of
"healthiness" of the chain just after starting up.

This change is needed to make this work  https://github.com/thrumdev/blobs/pull/190/commits/4a9f29e52d77ac676cf6a6153e99c1affbad3442#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03R38

Related #156 #157
