### PR TITLE
adapters/sovereign: configurable timeout

### DIFF
--- a/demo/sovereign/docker/rollup_config.docker.toml
+++ b/demo/sovereign/docker/rollup_config.docker.toml
@@ -1,6 +1,6 @@
 [da]
 sugondat_rpc = "ws://localhost:10995/"
-
+rpc_timeout_seconds = 180
 
 [storage]
 # The path to the rollup's data directory. Paths that do not begin with `/` are interpreted as relative paths.


### PR DESCRIPTION
Makes it possible to configure a timeout from the rollup_config.toml. At the same time
increased the timeout for the sovereign demo.