### PR TITLE
build: docker-compose

### DIFF
--- a/demo/rollkit/docker/Dockerfile
+++ b/demo/rollkit/docker/Dockerfile
@@ -27,7 +27,12 @@ RUN --mount=type=cache,target=/go/pkg \
 
 FROM golang:1.21 AS prod
 
+ENV TINI_VERSION v0.19.0
+ARG TARGETARCH
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
+RUN chmod +x /tini
+
 COPY --from=builder /go/bin/gmd /usr/local/bin/gmd
 COPY ./demo/rollkit/init-local.sh /root/init-local.sh
 WORKDIR /root
-ENTRYPOINT /usr/local/bin/gmd
+ENTRYPOINT ["/tini", "/root/init-local.sh"]

--- a/demo/rollkit/init-local.sh
+++ b/demo/rollkit/init-local.sh
@@ -10,7 +10,7 @@ TOKEN_AMOUNT="10000000000000000000000000stake"
 STAKING_AMOUNT="1000000000stake"
 
 # create a random Namespace ID for your rollup to post blocks to
-NAMESPACE=01020304050607080910111213141516
+NAMESPACE=00000000000011111111111111111111
 
 # query the DA Layer start height, in this case we are querying
 # our local devnet at port 26657, the RPC. The RPC endpoint is
@@ -77,13 +77,5 @@ gmd gentx $KEY_NAME $STAKING_AMOUNT --chain-id $CHAIN_ID --keyring-backend test
 # collect genesis transactions
 gmd collect-gentxs
 
-# create a restart-local.sh file to restart the chain later
-[ -f restart-local.sh ] && rm restart-local.sh
-echo "DA_BLOCK_HEIGHT=$DA_BLOCK_HEIGHT" >> restart-local.sh
-echo "NAMESPACE=$NAMESPACE" >> restart-local.sh
-echo "AUTH_TOKEN=$AUTH_TOKEN" >> restart-local.sh
-
-echo "gmd start --rollkit.aggregator true --rollkit.da_layer sugondat --rollkit.da_config='{\"base_url\":\"http://localhost:10995\",\"namespace\":\"$NAMESPACE\"}' --rollkit.namespace_id \$NAMESPACE --rollkit.da_start_height \$DA_BLOCK_HEIGHT --rpc.laddr tcp://127.0.0.1:36657 --p2p.laddr \"0.0.0.0:36656\"" >> restart-local.sh
-
 # start the chain
-gmd start --rollkit.aggregator true --rollkit.da_layer sugondat --rollkit.da_config='{"base_url":"http://localhost:10995","namespace":"0102030405060708"}' --rollkit.namespace_id 0102030405060708 --rollkit.da_start_height 1 --rpc.laddr tcp://127.0.0.1:36657 --p2p.laddr "0.0.0.0:36656"
+gmd start --rollkit.aggregator true --rollkit.da_layer sugondat --rollkit.da_config='{"base_url":"http://localhost:10995","namespace":"00000000000011111111111111111111"}' --rollkit.namespace_id 00000000000011111111111111111111 --rollkit.da_start_height 1 --rpc.laddr tcp://127.0.0.1:36657 --p2p.laddr "0.0.0.0:36656"

--- a/demo/rollkit/restart-local.sh
+++ b/demo/rollkit/restart-local.sh
@@ -1,4 +1,0 @@
-DA_BLOCK_HEIGHT=1
-NAMESPACE=01020304050607080910111213141516
-AUTH_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.mj7taF7Z9ZcTN2hhC1-cLf5SmqQd-ZA4YVZymd3-Ato
-gmd start --rollkit.aggregator true --rollkit.da_layer sugondat --rollkit.da_config='{"base_url":"http://localhost:10995","namespace":"01020304050607080910111213141516"}' --rollkit.namespace_id $NAMESPACE --rollkit.da_start_height $DA_BLOCK_HEIGHT --rpc.laddr tcp://127.0.0.1:36657 --p2p.laddr "0.0.0.0:36656"

--- a/demo/sovereign/docker/Dockerfile
+++ b/demo/sovereign/docker/Dockerfile
@@ -42,9 +42,9 @@ COPY . /sugondat
 
 ENV CONSTANTS_MANIFEST=/sugondat/demo/sovereign/constants.json
 RUN \
-    --mount=type=cache,target=/cargo/git \
-    --mount=type=cache,target=/cargo/registry \
-    --mount=type=cache,target=/cargo_target \
+    --mount=type=cache,id=demo-sovereign,target=/cargo/git \
+    --mount=type=cache,id=demo-sovereign,target=/cargo/registry \
+    --mount=type=cache,id=demo-sovereign,target=/cargo_target \
     cd demo/sovereign \
         && $CARGO_HOME/bin/cargo build --release --locked \
         && cp $CARGO_TARGET_DIR/release/sov-demo-rollup /usr/bin/sov-demo-rollup \
@@ -59,7 +59,8 @@ RUN \
         pkg-config
 
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ARG TARGETARCH
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
 RUN chmod +x /tini
 
 COPY --from=builder /usr/bin/sov-demo-rollup /usr/bin/sov-demo-rollup

--- a/demo/sovereign/docker/rollup_config.docker.toml
+++ b/demo/sovereign/docker/rollup_config.docker.toml
@@ -1,6 +1,6 @@
 [da]
 sugondat_rpc = "ws://localhost:10995/"
-
+rpc_timeout_seconds = 180
 
 [storage]
 # The path to the rollup's data directory. Paths that do not begin with `/` are interpreted as relative paths.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,60 @@
+# A couple of notes on this file.
+#
+# docker-compose takes over the control of the context meaning you don't pass it as an argument to
+# build. Instead, the context is specified relative to the location of this file. In turn, the
+# location of the dockerfile is relative to the context.
+
+name: sugondat
+
+services:
+  zombienet:
+    build:
+      context: ..
+      dockerfile: ./sugondat/chain/Dockerfile
+      target: zombienet
+    ports:
+      - "9988:9988"
+    # Mount /zombienet as tmpfs so as to avoid zombienet prompting if it should ignore existing
+    # directory.
+    tmpfs: /zombienet
+  shim:
+    build:
+      context: ..
+      dockerfile: ./sugondat/shim/Dockerfile
+    ports:
+      - "10995:10995"
+    # depends_on:
+    #   zombienet:
+    #     condition: service_healthy
+    environment:
+      - RUST_LOG=sugondat=trace
+    command: ["serve", "-p", "10995", "--node-url=ws://zombienet:9988", "--submit-dev-alice"]
+    # Health check.
+    #
+    # Note that if JSON-RPC returns an error, the health check will succeed. It's fine for now.
+    healthcheck:
+      test: [
+        "CMD-SHELL",
+        "curl -s -XPOST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"sovereign_getBlock\", \"params\":[1, \"0x00000000000000000000000000000000\"]}' http://localhost:10995/"]
+  gm:
+    build:
+      context: ..
+      dockerfile: ./demo/rollkit/docker/Dockerfile
+    depends_on:
+      shim:
+        condition: service_healthy
+    # This unites the Linux network namespace with the one of the `shim` service. That means that
+    # shim will be available via localhost.
+    network_mode: "service:shim"
+  sov:
+    build:
+      context: ..
+      dockerfile: ./demo/sovereign/docker/Dockerfile
+    depends_on:
+      shim:
+        condition: service_healthy
+    # Don't persist the rollup data directory.
+    tmpfs: /demo_data
+    # This unites the Linux network namespace with the one of the `shim` service. That means that
+    # shim will be available via localhost.
+    network_mode: "service:shim"

--- a/sugondat/chain/Dockerfile
+++ b/sugondat/chain/Dockerfile
@@ -1,4 +1,9 @@
-FROM ubuntu:20.04 as builder
+# HACK: Take note that this Dockerfile is meant to be used on x86-64 and apple silicon. However,
+# we have to use `--platform=amd64` even on macs relying on rosetta 2 to run the code. The reason
+# for that is zombienet requires a polkadot binary. Sadly, Polkadot is not packaged as a multi-
+# arch binary.
+
+FROM --platform=amd64 ubuntu:20.04 as builder
 
 LABEL org.opencontainers.image.source=https://github.com/thrumdev/blobs
 
@@ -36,18 +41,19 @@ RUN $CARGO_HOME/bin/rustup target add wasm32-unknown-unknown
 WORKDIR /sugondat
 COPY . /sugondat
 
-FROM builder AS builder-release
+FROM --platform=amd64 builder AS builder-release
 
-RUN --mount=type=cache,target=/cargo/git \
-    --mount=type=cache,target=/cargo/registry \
-    --mount=type=cache,target=/cargo_target \
+RUN --mount=type=cache,id=sugondat-chain,target=/cargo/git \
+    --mount=type=cache,id=sugondat-chain,target=/cargo/registry \
+    --mount=type=cache,id=sugondat-chain,target=/cargo_target \
     $CARGO_HOME/bin/cargo build --locked --release -p sugondat-node && \
         cp /cargo_target/release/sugondat-node /usr/bin/sugondat-node
 
-FROM ubuntu:20.04
+FROM --platform=amd64 ubuntu:20.04 as prod
 
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+# Hardcoded to amd64. See the comment at the top of this file.
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-amd64 /tini
 RUN chmod +x /tini
 
 RUN \
@@ -59,3 +65,22 @@ RUN \
 COPY --from=builder-release /usr/bin/sugondat-node /usr/bin/sugondat-node
 
 ENTRYPOINT ["/tini", "--", "/usr/bin/sugondat-node"]
+
+# This target supplements sugondat-node with all the sufficient components to spawn a full local
+# testnet (zombienet).
+FROM --platform=amd64 prod as zombienet
+
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
+RUN apt-get install -y nodejs multitail
+RUN npm install -g @zombienet/cli
+
+COPY --from=parity/polkadot:v1.4.0 /usr/bin/polkadot /usr/bin/
+COPY --from=parity/polkadot:v1.4.0 /usr/lib/polkadot/polkadot-prepare-worker /usr/bin/
+COPY --from=parity/polkadot:v1.4.0 /usr/lib/polkadot/polkadot-execute-worker /usr/bin/
+
+COPY ./testnet.toml /testnet.toml
+
+EXPOSE 9988
+
+VOLUME /zombienet
+ENTRYPOINT ["/tini", "--", "zombienet", "spawn", "--provider=native", "-d/zombienet/data", "/testnet.toml"]

--- a/sugondat/chain/node/src/proposer.rs
+++ b/sugondat/chain/node/src/proposer.rs
@@ -5,6 +5,7 @@
 //!    non-inherent extrinsics and avoid authoring empty blocks.
 //! 2. There is an incoming downward message from the relay chain.
 //! 3. There is a go-ahead signal for a parachain code upgrade.
+//! 4. The block is the first block of the parachain. Useful for testing.
 //!
 //! If any of these conditions are met, then the block is authored.
 
@@ -83,8 +84,13 @@ impl<P: ProposerInterface<Block> + Send> ProposerInterface<Block> for BlockLimit
                 Ok(None) => false,
             }
         };
+        let first_block = {
+            // allow creating the first block without the above conditions. This is useful for
+            // testing for detection of healthiness.
+            parent_header.number == 0
+        };
 
-        if has_downward_message || has_go_ahead || has_transactions {
+        if has_downward_message || has_go_ahead || has_transactions || first_block {
             self.inner
                 .propose(
                     parent_header,

--- a/sugondat/nmt/src/ns.rs
+++ b/sugondat/nmt/src/ns.rs
@@ -1,3 +1,5 @@
+use alloc::string::ToString;
+
 use crate::NS_ID_SIZE;
 use core::fmt;
 
@@ -13,7 +15,7 @@ use core::fmt;
 /// # use sugondat_nmt::Namespace;
 /// assert!(Namespace::from_u128_be(0x0100) > Namespace::from_u128_be(0x00FF));
 /// ````
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -68,5 +70,11 @@ impl fmt::Display for Namespace {
             write!(f, "{:02x}", byte)?;
         }
         Ok(())
+    }
+}
+
+impl fmt::Debug for Namespace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Namespace").field(&self.to_string()).finish()
     }
 }

--- a/sugondat/shim/Dockerfile
+++ b/sugondat/shim/Dockerfile
@@ -37,16 +37,17 @@ COPY . /sugondat
 
 FROM builder AS builder-release
 
-RUN --mount=type=cache,target=/cargo/git \
-    --mount=type=cache,target=/cargo/registry \
-    --mount=type=cache,target=/cargo_target \
+RUN --mount=type=cache,id=sugondat-shim,target=/cargo/git \
+    --mount=type=cache,id=sugondat-shim,target=/cargo/registry \
+    --mount=type=cache,id=sugondat-shim,target=/cargo_target \
     $CARGO_HOME/bin/cargo build --locked --release -p sugondat-shim && \
         cp /cargo_target/release/sugondat-shim /usr/bin/sugondat-shim
 
 FROM ubuntu:20.04
 
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ARG TARGETARCH
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /tini
 RUN chmod +x /tini
 
 RUN \

--- a/sugondat/shim/src/dock/rollkit.rs
+++ b/sugondat/shim/src/dock/rollkit.rs
@@ -56,7 +56,7 @@ impl RollkitRPCServer for RollkitDock {
             self.client
                 .submit_blob(blob.data, namespace, submit_key.clone())
                 .await
-                .map_err(|_| err::submission_error())?;
+                .map_err(err::submission_error)?;
         }
         // TODO:
         Ok(0)
@@ -70,6 +70,12 @@ impl RollkitRPCServer for RollkitDock {
 fn parse_namespace(namespace: &str) -> anyhow::Result<sugondat_nmt::Namespace> {
     use sugondat_nmt::NS_ID_SIZE;
     let namespace_bytes = hex::decode(namespace)?;
+    if namespace_bytes.len() != NS_ID_SIZE {
+        debug!(
+            "The namespace '{}' is not {} bytes long. Resizing...",
+            namespace, NS_ID_SIZE
+        );
+    }
     let namespace_bytes = match namespace_bytes.len() {
         0 => anyhow::bail!("namespace must not be empty"),
         1..=NS_ID_SIZE => {

--- a/sugondat/shim/src/dock/rpc_error.rs
+++ b/sugondat/shim/src/dock/rpc_error.rs
@@ -16,10 +16,10 @@ pub fn no_signing_key() -> ErrorObjectOwned {
     )
 }
 
-pub fn submission_error() -> ErrorObjectOwned {
+pub fn submission_error(e: anyhow::Error) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(
         jsonrpsee::types::error::INTERNAL_ERROR_CODE,
-        "Internal Error: failed to submit blob",
+        format!("Internal Error: failed to submit blob: {:?}", e),
         None::<()>,
     )
 }

--- a/sugondat/shim/src/dock/sovereign.rs
+++ b/sugondat/shim/src/dock/sovereign.rs
@@ -69,7 +69,7 @@ impl SovereignRPCServer for SovereignDock {
         self.client
             .submit_blob(blob, namespace, submit_key)
             .await
-            .map_err(|_| err::submission_error())?;
+            .map_err(err::submission_error)?;
         Ok(())
     }
 }

--- a/sugondat/shim/src/sugondat_rpc/mod.rs
+++ b/sugondat/shim/src/sugondat_rpc/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 use crate::key::Keypair;
 use anyhow::Context;
@@ -343,7 +343,6 @@ pub struct Block {
 }
 
 /// Represents a blob in a sugondat block.
-#[derive(Debug)]
 pub struct Blob {
     pub extrinsic_index: u32,
     pub namespace: Namespace,
@@ -355,5 +354,23 @@ impl Blob {
     pub fn sha2_hash(&self) -> [u8; 32] {
         use sha2::Digest;
         sha2::Sha256::digest(&self.data).into()
+    }
+}
+
+impl fmt::Debug for Blob {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let abridged_data = if self.data.len() > 16 {
+            let mut s = hex::encode(&self.data[..16]);
+            s.push_str("...");
+            s
+        } else {
+            hex::encode(&self.data)
+        };
+        f.debug_struct("Blob")
+            .field("extrinsic_index", &self.extrinsic_index)
+            .field("namespace", &self.namespace)
+            .field("sender", &self.sender)
+            .field("data", &abridged_data)
+            .finish()
     }
 }


### PR DESCRIPTION
    This commit introduces docker/docker-compose.yml. Thanks to it
    you can now spin up a network with just one command:

            docker compose -f docker/docker-compose.yml --build up

    That will launch the polkadot localnet, the parachain node, the shim
    and the demoes: gm (based on rollkit) and the sovereign demo.

    Besides that this commit adds explicit cache IDs: that seems to improve
    the caching behavior when running builds from docker-compose.

    Atm, parity/polkadot image isn't multi-arch and doesn't support arm64.
    To properly support macOS builds I opted to build the whole thing inside
    amd64. It seems it has ok performance.

    Also, I wrapped the docker entrypoints in tini. This solves the problem
    of propagating the SIGTERM/SIGINT when stopping the services.