### PR TITLE
shim: add wait flag

### DIFF
--- a/sugondat/shim/src/cli.rs
+++ b/sugondat/shim/src/cli.rs
@@ -171,6 +171,25 @@ pub mod query {
         Hash([u8; 32]),
     }
 
+    #[derive(Debug, Args)]
+    pub struct BlockParams {
+        /// The block containing the blob to query.
+        ///
+        /// Possible values: ["best", number, hash]
+        ///
+        /// "best" is the highest finalized block.
+        ///
+        /// Hashes must be 32 bytes, hex-encoded, and prefixed with "0x".
+        #[arg(value_name = "BLOCK_REF")]
+        pub block_ref: BlockRef,
+
+        /// By default, if the block is not available (e.g. not yet produced), the shim will return immediately.
+        ///
+        /// By specifying this flag, the shim will wait until the block is available.
+        #[clap(long)]
+        pub wait: bool,
+    }
+
     impl std::fmt::Display for BlockRef {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
             match *self {
@@ -221,22 +240,15 @@ pub mod query {
     pub mod blob {
         use clap::Args;
 
-        use super::{BlockRef, SugondatRpcParams};
+        use super::{BlockParams, SugondatRpcParams};
 
         #[derive(Debug, Args)]
         pub struct Params {
             #[clap(flatten)]
             pub rpc: SugondatRpcParams,
 
-            /// The block containing the blob to query.
-            ///
-            /// Possible values: ["best", number, hash]
-            ///
-            /// "best" is the highest finalized block.
-            ///
-            /// Hashes must be 32 bytes, hex-encoded, and prefixed with "0x".
-            #[arg(value_name = "BLOCK_REF")]
-            pub block: BlockRef,
+            #[clap(flatten)]
+            pub block: BlockParams,
 
             /// The index of the extrinsic (transaction) containing the blob.
             #[arg(value_name = "INDEX")]
@@ -254,22 +266,15 @@ pub mod query {
 
         use clap::Args;
 
-        use super::{BlockRef, SugondatRpcParams};
+        use super::{BlockParams, SugondatRpcParams};
 
         #[derive(Debug, Args)]
         pub struct Params {
             #[clap(flatten)]
             pub rpc: SugondatRpcParams,
 
-            /// The block to query information about.
-            ///
-            /// Possible values: ["best", number, hash]
-            ///
-            /// "best" is the highest finalized block.
-            ///
-            /// Hashes must be 32 bytes, hex-encoded, and prefixed with "0x".
-            #[arg(default_value_t = BlockRef::Best, value_name = "BLOCK_REF")]
-            pub block: BlockRef,
+            #[clap(flatten)]
+            pub block: BlockParams,
         }
     }
 

--- a/sugondat/shim/src/cmd/query/blob.rs
+++ b/sugondat/shim/src/cmd/query/blob.rs
@@ -1,5 +1,5 @@
-use super::connect_rpc;
-use crate::cli::query::{blob::Params, BlockRef};
+use super::{connect_rpc, get_block_at};
+use crate::cli::query::blob::Params;
 
 use std::io::Write;
 
@@ -12,20 +12,7 @@ pub async fn run(params: Params) -> anyhow::Result<()> {
     } = params;
 
     let client = connect_rpc(rpc).await?;
-
-    let maybe_hash = match block {
-        BlockRef::Best => None,
-        BlockRef::Hash(h) => Some(h),
-        BlockRef::Number(n) => Some(
-            client
-                .block_hash(n)
-                .await?
-                .ok_or_else(|| anyhow::anyhow!("No block with number {}", n))?
-                .0,
-        ),
-    };
-
-    let block = client.get_block_at(maybe_hash).await?;
+    let block = get_block_at(&client, block).await?;
 
     let i = block
         .blobs

--- a/sugondat/shim/src/cmd/query/block.rs
+++ b/sugondat/shim/src/cmd/query/block.rs
@@ -1,24 +1,11 @@
-use super::connect_rpc;
-use crate::cli::query::{block::Params, BlockRef};
+use super::{connect_rpc, get_block_at};
+use crate::cli::query::block::Params;
 
 pub async fn run(params: Params) -> anyhow::Result<()> {
     let Params { rpc, block } = params;
 
     let client = connect_rpc(rpc).await?;
-
-    let maybe_hash = match block {
-        BlockRef::Best => None,
-        BlockRef::Hash(h) => Some(h),
-        BlockRef::Number(n) => Some(
-            client
-                .block_hash(n)
-                .await?
-                .ok_or_else(|| anyhow::anyhow!("No block with number {}", n))?
-                .0,
-        ),
-    };
-
-    let block = client.get_block_at(maybe_hash).await?;
+    let block = get_block_at(&client, block).await?;
 
     println!("Block: #{}", block.number);
     println!("  Hash: 0x{}", hex::encode(&block.hash[..]));

--- a/sugondat/shim/src/cmd/query/mod.rs
+++ b/sugondat/shim/src/cmd/query/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::query::{Commands, Params},
+    cli::query::{BlockParams, BlockRef, Commands, Params},
     sugondat_rpc,
 };
 
@@ -14,6 +14,30 @@ pub async fn run(params: Params) -> anyhow::Result<()> {
         Commands::Blob(params) => blob::run(params).await?,
     }
     Ok(())
+}
+
+/// Given the BlockParams and the client to be used, try to fetch
+/// the corresponding block. It will wait until the block is avaiable if specified.
+pub async fn get_block_at(
+    client: &sugondat_rpc::Client,
+    block: BlockParams,
+) -> anyhow::Result<sugondat_rpc::Block> {
+    let maybe_hash = match block.block_ref {
+        BlockRef::Best => None,
+        BlockRef::Hash(h) => Some(h),
+        BlockRef::Number(n) => Some(match block.wait {
+            true => client.wait_block_hash(n).await,
+            false => client
+                .block_hash(n)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("No block with number {}", n))?,
+        }),
+    };
+
+    match block.wait {
+        true => client.wait_block_at(maybe_hash).await,
+        false => client.get_block_at(maybe_hash).await,
+    }
 }
 
 async fn connect_rpc(

--- a/sugondat/shim/src/dock/rollkit.rs
+++ b/sugondat/shim/src/dock/rollkit.rs
@@ -34,7 +34,7 @@ impl RollkitRPCServer for RollkitDock {
         );
         let namespace = parse_namespace(&namespace).map_err(|_| err::bad_namespace())?;
         let block_hash = self.client.wait_finalized_height(height).await;
-        let block = self.client.get_block_at(Some(block_hash)).await.unwrap();
+        let block = self.client.wait_block_at(Some(block_hash)).await.unwrap();
         let mut blobs = vec![];
         for blob in block.blobs {
             if blob.namespace == namespace {

--- a/sugondat/shim/src/dock/sovereign.rs
+++ b/sugondat/shim/src/dock/sovereign.rs
@@ -34,7 +34,7 @@ impl SovereignRPCServer for SovereignDock {
     ) -> Result<Block, ErrorObjectOwned> {
         info!("get_block({})", height);
         let block_hash = self.client.wait_finalized_height(height).await;
-        let block = self.client.get_block_at(Some(block_hash)).await.unwrap();
+        let block = self.client.wait_block_at(Some(block_hash)).await.unwrap();
         let proof = make_namespace_proof(&block, namespace);
         let blobs = block
             .blobs


### PR DESCRIPTION
Add a struct used to contain both BlockRef and the wait flag, to make it reusable for both block and blob queries (and all other possible new queries).

The struct should be used with `clap(flatten)` to make all the fields appear as options in the query command.

TODOs:

+ [x] Better naming
+ [x] Better logging

closes #171

It would also be great to add something like `wait-interval` to specify how often the request of the block should be made (in `wait_header_and_extrinsics`). Currently, I've set a two-second sleep between each call