### PR TITLE
remove unnecessary storage item in length fee adjustment

### DIFF
--- a/sugondat/chain/pallets/length-fee-adjustment/src/mock.rs
+++ b/sugondat/chain/pallets/length-fee-adjustment/src/mock.rs
@@ -11,6 +11,9 @@ use sp_runtime::{
     FixedPointNumber, SaturatedConversion,
 };
 
+use pallet_sugondat_length_fee_adjustment::LastRelayBlockNumberProvider;
+use polkadot_primitives::v6::BlockNumber as RelayChainBlockNumber;
+
 type Block = frame_system::mocking::MockBlock<Test>;
 type Balance = u64;
 
@@ -87,6 +90,19 @@ parameter_types! {
 
     pub static WeightToFee: u64 = 1;
     pub static OperationalFeeMultiplier: u8 = 5;
+    pub static LastRelayBlockNumber: RelayChainBlockNumber = 0;
+}
+
+pub struct MockLastRelayBlockNumberProvider;
+
+impl LastRelayBlockNumberProvider for MockLastRelayBlockNumberProvider {
+    fn last_relay_block_number() -> RelayChainBlockNumber {
+        LastRelayBlockNumber::get()
+    }
+}
+
+pub fn set_last_relay_block_number(n: RelayChainBlockNumber) {
+    LastRelayBlockNumber::mutate(|x| *x = n);
 }
 
 impl WeightToFeeT for WeightToFee {
@@ -114,4 +130,5 @@ impl pallet_sugondat_length_fee_adjustment::Config for Test {
     type MinimumMultiplierBlockSize = MinimumMultiplierBlockSize;
     type MaximumMultiplierBlockSize = MaximumMultiplierBlockSize;
     type SkippedBlocksNumberTerms = SkippedBlocksNumberTerms;
+    type LastRelayBlockNumberProvider = MockLastRelayBlockNumberProvider;
 }

--- a/sugondat/chain/runtimes/sugondat-kusama/src/lib.rs
+++ b/sugondat/chain/runtimes/sugondat-kusama/src/lib.rs
@@ -312,6 +312,7 @@ impl pallet_sugondat_length_fee_adjustment::Config for Runtime {
     type MaximumMultiplierBlockSize = MaximumMultiplierBlockSize;
     type MinimumMultiplierBlockSize = MinimumMultiplierBlockSize;
     type SkippedBlocksNumberTerms = SkippedBlocksNumberTerms;
+    type LastRelayBlockNumberProvider = Runtime;
 }
 
 pub type SlowAdjustingFeeUpdate<R> = TargetedFeeAdjustment<

--- a/sugondat/chain/runtimes/test/src/lib.rs
+++ b/sugondat/chain/runtimes/test/src/lib.rs
@@ -379,6 +379,7 @@ impl pallet_sugondat_length_fee_adjustment::Config for Runtime {
     type MaximumMultiplierBlockSize = MaximumMultiplierBlockSize;
     type MinimumMultiplierBlockSize = MinimumMultiplierBlockSize;
     type SkippedBlocksNumberTerms = SkippedBlocksNumberTerms;
+    type LastRelayBlockNumberProvider = Runtime;
 }
 
 pub type SlowAdjustingFeeUpdate<R> = TargetedFeeAdjustment<


### PR DESCRIPTION
Tracking the previous relay parent number is already done by parachain system. No need to introduce a redundancy.