### PR TITLE
gh-runner: add rust-src as a component

### DIFF
--- a/docker/gha-runner.Dockerfile
+++ b/docker/gha-runner.Dockerfile
@@ -34,6 +34,7 @@ RUN \
 ENV PATH=$CARGO_HOME/bin:$PATH
 
 RUN rustup target add wasm32-unknown-unknown
+RUN rustup component add rust-src
 
 # Install cargo binstall, using it install cargo-risczero, and using it install risc0 toolchain.
 RUN curl \


### PR DESCRIPTION
Wasm build in 1.6.0 seems to require this. The runner needs to be re-deployed once it's merged.