### PR TITLE
fix sugondat-primitives not compiling in release

### DIFF
--- a/sugondat/chain/node/Cargo.toml
+++ b/sugondat/chain/node/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = { workspace = true }
 # Local
 sugondat-test-runtime = { workspace = true }
 sugondat-kusama-runtime = { workspace = true }
-sugondat-primitives = { workspace = true }
+sugondat-primitives = { workspace = true, default-features = true }
 
 # Substrate
 frame-benchmarking = { workspace = true, default-features = true }

--- a/sugondat/chain/primitives/src/lib.rs
+++ b/sugondat/chain/primitives/src/lib.rs
@@ -57,6 +57,7 @@ pub enum InvalidTransactionCustomError {
     InvalidNamespaceId = 101,
 }
 
+#[cfg(feature = "std")]
 pub fn last_relay_block_number_key() -> Vec<u8> {
     [
         sp_core::twox_128(b"ParachainSystem"),


### PR DESCRIPTION
Just a quick fix to avoid compiling `last_relay_block_number_key` in no_std, 
this made me think, is it worth to have this function in sugondat-primitives?
it is just used once in the node proposer
