### PR TITLE
shim, primitives: move namespace validation logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7277,8 +7277,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "quickcheck",
- "quickcheck_macros",
  "scale-info",
  "sha2 0.10.8",
  "sp-core",
@@ -13478,6 +13476,8 @@ name = "sugondat-primitives"
 version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
+ "quickcheck",
+ "quickcheck_macros",
  "sp-consensus-aura",
  "sp-core",
  "sp-runtime",
@@ -13509,6 +13509,7 @@ dependencies = [
  "subxt",
  "subxt-signer",
  "sugondat-nmt",
+ "sugondat-primitives",
  "sugondat-shim-common-rollkit",
  "sugondat-shim-common-sovereign",
  "sugondat-subxt",

--- a/sugondat/chain/pallets/blobs/Cargo.toml
+++ b/sugondat/chain/pallets/blobs/Cargo.toml
@@ -30,8 +30,6 @@ sugondat-nmt = { workspace = true }
 
 [dev-dependencies]
 sugondat-nmt = { workspace = true, default-features = true }
-quickcheck = { workspace = true }
-quickcheck_macros = { workspace = true }
 
 # Substrate
 sp-core = { workspace = true }

--- a/sugondat/chain/pallets/blobs/src/namespace_param.rs
+++ b/sugondat/chain/pallets/blobs/src/namespace_param.rs
@@ -1,35 +1,9 @@
 //! Namespaces as a parameter.
-//!
-//! Namespaces are encoded as 16-byte arrays, with the following schema:
-//!   - The first byte is reserved for a version byte which determines the format
-//!     of the following 15 bytes. At the moment, the only supported value for this byte
-//!     is `0x00`, which indicates version 0.
-//!   - In version 0, bytes 1 through 5 are required to be equal to `0x00` and bytes 6 through
-//!     15 are allowed to hold any value.
 
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
-
-/// An error in namespace validation.
-pub enum NamespaceValidationError {
-    /// Unrecognized version.
-    UnrecognizedVersion(u8),
-    /// V0: reserved bytes are non-zero.
-    V0NonZeroReserved,
-}
-
-/// Validate a namespace against known schemas.
-pub fn validate(namespace: &[u8; 16]) -> Result<(), NamespaceValidationError> {
-    if namespace[0] != 0 {
-        return Err(NamespaceValidationError::UnrecognizedVersion(namespace[0]));
-    }
-    if &namespace[1..6] != &[0, 0, 0, 0, 0] {
-        return Err(NamespaceValidationError::V0NonZeroReserved);
-    }
-
-    Ok(())
-}
+use sugondat_primitives::namespace;
 
 /// Type-safe wrapper around an unvalidated blob namespace.
 #[derive(Encode, Decode, TypeInfo, MaxEncodedLen, Clone, PartialEq, RuntimeDebug)]
@@ -37,8 +11,8 @@ pub struct UnvalidatedNamespace([u8; 16]);
 
 impl UnvalidatedNamespace {
     /// Validate the namespace, extracting the full data.
-    pub fn validate(&self) -> Result<u128, NamespaceValidationError> {
-        validate(&self.0).map(|()| u128::from_be_bytes(self.0))
+    pub fn validate(&self) -> Result<u128, namespace::NamespaceValidationError> {
+        namespace::validate(&self.0).map(|()| u128::from_be_bytes(self.0))
     }
 }
 
@@ -51,49 +25,5 @@ impl From<[u8; 16]> for UnvalidatedNamespace {
 impl From<u128> for UnvalidatedNamespace {
     fn from(x: u128) -> Self {
         UnvalidatedNamespace(x.to_be_bytes())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use quickcheck::TestResult;
-    use quickcheck_macros::quickcheck;
-    use std::matches;
-
-    #[quickcheck]
-    fn namespace_validation_not_v0_fails(version_byte: u8) -> TestResult {
-        if version_byte == 0x00 {
-            return TestResult::discard();
-        }
-        TestResult::from_bool(matches!(
-            validate(&[version_byte, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-            Err(NamespaceValidationError::UnrecognizedVersion(v)) if v == version_byte,
-        ))
-    }
-
-    #[quickcheck]
-    fn namespace_validation_v0_reserved_occupied_fails(
-        reserved: (u8, u8, u8, u8, u8),
-    ) -> TestResult {
-        if reserved == (0, 0, 0, 0, 0) {
-            return TestResult::discard();
-        }
-        let (a, b, c, d, e) = reserved;
-        TestResult::from_bool(matches!(
-            validate(&[0u8, a, b, c, d, e, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-            Err(NamespaceValidationError::V0NonZeroReserved),
-        ))
-    }
-
-    #[quickcheck]
-    fn namespace_validation_v0_works(namespace: Vec<u8>) -> TestResult {
-        if namespace.len() < 10 {
-            return TestResult::discard();
-        }
-
-        let mut n = [0u8; 16];
-        n[6..].copy_from_slice(&namespace[..10]);
-        TestResult::from_bool(matches!(validate(&n), Ok(())))
     }
 }

--- a/sugondat/chain/primitives/Cargo.toml
+++ b/sugondat/chain/primitives/Cargo.toml
@@ -16,6 +16,10 @@ sp-runtime = { workspace = true }
 sp-core = { workspace = true }
 sp-consensus-aura = { workspace = true }
 
+[dev-dependencies]
+quickcheck = { workspace = true }
+quickcheck_macros = { workspace = true }
+
 [features]
 default = ["std"]
 std = ["parity-scale-codec/std", "sp-runtime/std", "sp-core/std", "sp-consensus-aura/std"]

--- a/sugondat/chain/primitives/src/lib.rs
+++ b/sugondat/chain/primitives/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod namespace;
+
 use sp_runtime::{
     traits::{IdentifyAccount, Verify},
     MultiSignature,

--- a/sugondat/chain/primitives/src/namespace.rs
+++ b/sugondat/chain/primitives/src/namespace.rs
@@ -1,0 +1,86 @@
+//! Namespaces are encoded as 16-byte arrays, with the following schema:
+//!   - The first byte is reserved for a version byte which determines the format
+//!     of the following 15 bytes. At the moment, the only supported value for this byte
+//!     is `0x00`, which indicates version 0.
+//!   - In version 0, bytes 1 through 5 are required to be equal to `0x00` and bytes 6 through
+//!     15 are allowed to hold any value.
+
+use core::fmt;
+
+/// An error in namespace validation.
+#[derive(Debug)]
+pub enum NamespaceValidationError {
+    /// Unrecognized version.
+    UnrecognizedVersion(u8),
+    /// V0: reserved bytes are non-zero.
+    V0NonZeroReserved,
+}
+
+impl fmt::Display for NamespaceValidationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            NamespaceValidationError::UnrecognizedVersion(version) => {
+                core::write!(f, "Unrecognized version: V{}", version)
+            }
+            NamespaceValidationError::V0NonZeroReserved => {
+                core::write!(f, "V0: reserved bytes are non-zero")
+            }
+        }
+    }
+}
+
+/// Validate a namespace against known schemas.
+pub fn validate(namespace: &[u8; 16]) -> Result<(), NamespaceValidationError> {
+    if namespace[0] != 0 {
+        return Err(NamespaceValidationError::UnrecognizedVersion(namespace[0]));
+    }
+    if &namespace[1..6] != &[0, 0, 0, 0, 0] {
+        return Err(NamespaceValidationError::V0NonZeroReserved);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::TestResult;
+    use quickcheck_macros::quickcheck;
+    use std::matches;
+
+    #[quickcheck]
+    fn namespace_validation_not_v0_fails(version_byte: u8) -> TestResult {
+        if version_byte == 0x00 {
+            return TestResult::discard();
+        }
+        TestResult::from_bool(matches!(
+            validate(&[version_byte, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            Err(NamespaceValidationError::UnrecognizedVersion(v)) if v == version_byte,
+        ))
+    }
+
+    #[quickcheck]
+    fn namespace_validation_v0_reserved_occupied_fails(
+        reserved: (u8, u8, u8, u8, u8),
+    ) -> TestResult {
+        if reserved == (0, 0, 0, 0, 0) {
+            return TestResult::discard();
+        }
+        let (a, b, c, d, e) = reserved;
+        TestResult::from_bool(matches!(
+            validate(&[0u8, a, b, c, d, e, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            Err(NamespaceValidationError::V0NonZeroReserved),
+        ))
+    }
+
+    #[quickcheck]
+    fn namespace_validation_v0_works(namespace: Vec<u8>) -> TestResult {
+        if namespace.len() < 10 {
+            return TestResult::discard();
+        }
+
+        let mut n = [0u8; 16];
+        n[6..].copy_from_slice(&namespace[..10]);
+        TestResult::from_bool(matches!(validate(&n), Ok(())))
+    }
+}

--- a/sugondat/shim/Cargo.toml
+++ b/sugondat/shim/Cargo.toml
@@ -12,6 +12,7 @@ edition.workspace = true
 [dependencies]
 sugondat-nmt = { workspace = true, default-features = true, features = ["serde"] }
 sugondat-subxt = { workspace = true }
+sugondat-primitives = { workspace = true, default-features = true }
 sugondat-shim-common-sovereign = { workspace = true, default-features = true, features = ["server"] }
 sugondat-shim-common-rollkit = { workspace = true }
 


### PR DESCRIPTION
The logic is moved from the pallet blobs into primitives
to share it with the shim and provide useful error messaging
when an invalid namespace is provided in the submit command

closes #185 