### PR TITLE
node: add alias to command ExportGenesisHead

### DIFF
--- a/sugondat/chain/node/src/cli.rs
+++ b/sugondat/chain/node/src/cli.rs
@@ -34,6 +34,9 @@ pub enum Subcommand {
     ExportGenesisMetadata(export_genesis_metadata::ExportGenesisMetadataCmd),
 
     /// Export the genesis head-data of the parachain.
+    ///
+    /// Head data is the encoded block header.
+    #[command(alias = "export-genesis-state")]
     ExportGenesisHead(cumulus_client_cli::ExportGenesisHeadCommand),
 
     /// Export the genesis wasm of the parachain.


### PR DESCRIPTION
`export-genesis-state` is needed as alias to the command ExportGenesisHead
because zombienet rely on that command

In [this](https://github.com/paritytech/polkadot-sdk/commit/8683bbeefb688364f5f9e445dffb42fc266dd8f0) commit, the change to the command was introduced, while also maintaining backward compatibility (as stated at the end of the commit message)