### PR TITLE
ci: introducing xtask ci testing

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,6 +2903,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
+name = "duct"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
+
+[[package]]
 name = "dyn-clonable"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6344,6 +6356,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11594,6 +11616,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "shlex"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15459,6 +15491,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "duct",
+ "tracing",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ members = [
     "sugondat/shim",
     "sugondat/shim/common/rollkit",
     "sugondat/shim/common/sovereign",
-    "sugondat/subxt-autogen"
+    "sugondat/subxt-autogen",
+    "xtask"
 ]
 
 [workspace.package]
@@ -177,3 +178,6 @@ sugondat-kusama-runtime = { path = "sugondat/chain/runtimes/sugondat-kusama" }
 sugondat-primitives = { path = "sugondat/chain/primitives", default-features = false }
 pallet-sugondat-blobs = { path = "sugondat/chain/pallets/blobs", default-features = false }
 pallet-sugondat-length-fee-adjustment = { path = "sugondat/chain/pallets/length-fee-adjustment", default-features = false }
+
+# xtask
+duct = { version = "0.13.7" }

--- a/demo/sovereign/demo-rollup/provers/risc0/guest-sugondat/Cargo.lock
+++ b/demo/sovereign/demo-rollup/provers/risc0/guest-sugondat/Cargo.lock
@@ -108,18 +108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,12 +395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,10 +614,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
 dependencies = [
  "arrayvec",
- "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "serde",
 ]
 
 [[package]]
@@ -737,12 +717,6 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1355,12 +1329,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,15 +1505,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "zerocopy"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+duct = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -1,0 +1,36 @@
+use crate::{cli::test::BuildParams, run_maybe_quiet};
+use duct::cmd;
+use tracing::info;
+
+// TODO: https://github.com/thrumdev/blobs/issues/225
+
+pub fn build(params: BuildParams) -> anyhow::Result<()> {
+    if params.skip {
+        return Ok(());
+    }
+
+    // `it is advisable to use CARGO environmental variable to get the right cargo`
+    // quoted by xtask readme
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+
+    info!("Start building sugondat-node");
+    run_maybe_quiet(
+        cmd!(&cargo, "build", "-p", "sugondat-node", "--release"),
+        params.quiet,
+    )?;
+
+    info!("Start building sugondat-node");
+    run_maybe_quiet(
+        cmd!(&cargo, "build", "-p", "sugondat-shim", "--release"),
+        params.quiet,
+    )?;
+
+    info!("Start building sovereign demo-rollup");
+
+    run_maybe_quiet(
+        cmd!(&cargo, "build", "--release").dir("demo/sovereign/demo-rollup"),
+        params.quiet,
+    )?;
+
+    Ok(())
+}

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -1,0 +1,67 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    Test(test::Params),
+}
+
+pub mod test {
+
+    // TODO: https://github.com/thrumdev/blobs/issues/224
+    use clap::Args;
+    #[derive(Debug, Args)]
+    pub struct Params {
+        #[clap(flatten)]
+        pub build: BuildParams,
+
+        #[clap(flatten)]
+        pub shim: ShimParams,
+
+        #[clap(flatten)]
+        pub zombienet: ZombienetParams,
+
+        #[clap(flatten)]
+        pub sovereign: SovereignParams,
+    }
+
+    #[derive(clap::Args, Debug, Clone)]
+    pub struct BuildParams {
+        /// Skip building required binaries
+        /// (sugondat-node, sugondat-shim, sov-demo-rollup and sov-cli)
+        #[clap(default_value = "false")]
+        #[arg(long = "build-skip", value_name = "skip", id = "build.skip")]
+        pub skip: bool,
+
+        /// Don't print to stdout during the build process
+        #[arg(long = "build-quiet", value_name = "quiet", id = "build.quiet")]
+        pub quiet: bool,
+    }
+
+    #[derive(clap::Args, Debug, Clone)]
+    pub struct ShimParams {
+        /// Don't print shim process stdout
+        #[arg(long = "shim-quiet", value_name = "quiet", id = "shim.quiet")]
+        pub quiet: bool,
+    }
+
+    #[derive(clap::Args, Debug, Clone)]
+    pub struct ZombienetParams {
+        /// Don't print zombienet process stdout
+        #[arg(long = "zombienet-quiet", value_name = "quiet", id = "zombienet.quiet")]
+        pub quiet: bool,
+    }
+
+    #[derive(clap::Args, Debug, Clone)]
+    pub struct SovereignParams {
+        /// Don't print sovereing rollup processes stdout
+        #[arg(long = "sovereign-quiet", value_name = "quiet", id = "sovereign.quiet")]
+        pub quiet: bool,
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,66 @@
+mod build;
+mod cli;
+mod shim;
+mod sovereign;
+mod zombienet;
+
+use clap::Parser;
+use cli::{test, Cli, Commands};
+
+fn main() -> anyhow::Result<()> {
+    init_logging()?;
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Test(params) => test(params)?,
+    }
+
+    Ok(())
+}
+
+fn test(params: test::Params) -> anyhow::Result<()> {
+    build::build(params.build)?;
+
+    // the variables must be kept alive and not dropped
+    // otherwise the child process will be killed
+    #[allow(unused)]
+    let zombienet = zombienet::Zombienet::try_new(params.zombienet)?;
+    #[allow(unused)]
+    let shim = shim::Shim::try_new(params.shim)?;
+    let sovereign = sovereign::Sovereign::try_new(params.sovereign)?;
+
+    // TODO: https://github.com/thrumdev/blobs/issues/226
+    // Wait for the sovereign rollup to be ready
+    std::thread::sleep(std::time::Duration::from_secs(20));
+
+    sovereign.test_sovereign_rollup()?;
+
+    Ok(())
+}
+
+fn init_logging() -> anyhow::Result<()> {
+    use tracing_subscriber::fmt;
+    use tracing_subscriber::prelude::*;
+    let filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+        .from_env_lossy();
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(filter)
+        .try_init()?;
+    Ok(())
+}
+
+fn run_maybe_quiet(cmd: duct::Expression, quiet: bool) -> std::io::Result<std::process::Output> {
+    match quiet {
+        true => cmd.stdout_null().run(),
+        false => cmd.run(),
+    }
+}
+
+fn start_maybe_quiet(cmd: duct::Expression, quiet: bool) -> std::io::Result<duct::Handle> {
+    match quiet {
+        true => cmd.stdout_null().start(),
+        false => cmd.start(),
+    }
+}

--- a/xtask/src/shim.rs
+++ b/xtask/src/shim.rs
@@ -1,0 +1,33 @@
+use crate::{cli::test::ShimParams, run_maybe_quiet, start_maybe_quiet};
+use duct::cmd;
+use tracing::info;
+
+pub struct Shim(duct::Handle);
+
+impl Shim {
+    // Try launching the shim, it requires an up an running sugondat-node
+    pub fn try_new(params: ShimParams) -> anyhow::Result<Self> {
+        // Wait for the shim to be connected, which indicates that the network is ready
+        info!("Wait for the network to be ready");
+        run_maybe_quiet(
+            cmd!("sugondat-shim", "query", "block", "--wait", "1",).dir("target/release/"),
+            params.quiet,
+        )?;
+
+        info!("Launching Shim");
+        let shim_handle = start_maybe_quiet(
+            cmd!("sugondat-shim", "serve", "--submit-dev-alice").dir("target/release/"),
+            params.quiet,
+        )?;
+
+        Ok(Self(shim_handle))
+    }
+}
+
+impl Drop for Shim {
+    // duct::Handle does not implement kill on drop
+    fn drop(&mut self) {
+        info!("Shim process is going to be killed");
+        let _ = self.0.kill();
+    }
+}

--- a/xtask/src/sovereign.rs
+++ b/xtask/src/sovereign.rs
@@ -1,0 +1,95 @@
+use crate::{cli::test::SovereignParams, start_maybe_quiet};
+use anyhow::bail;
+use duct::cmd;
+use tracing::info;
+
+pub struct Sovereign(duct::Handle);
+
+impl Sovereign {
+    // Try launching the sovereing rollup using zombienet
+    pub fn try_new(params: SovereignParams) -> anyhow::Result<Self> {
+        info!("Deleting rollup db if it already exists");
+        cmd!("rm", "-r", "demo/sovereign/demo-rollup/demo_data")
+            .unchecked()
+            .run()?;
+
+        //TODO: https://github.com/thrumdev/blobs/issues/227
+        info!("Launching sovereign rollup");
+        #[rustfmt::skip]
+        let sovereign_handle = start_maybe_quiet(
+            cmd!(
+                "sh", "-c",
+                "cd demo/sovereign/demo-rollup && ./../target/release/sov-demo-rollup"
+            ),
+            params.quiet,
+        )?;
+
+        Ok(Self(sovereign_handle))
+    }
+
+    // All the networks must be up (relaychain and sugondat-node), including the sovereign rollup."
+    pub fn test_sovereign_rollup(&self) -> anyhow::Result<()> {
+        info!("Running sovereign rollup test");
+
+        //TODO: https://github.com/thrumdev/blobs/issues/227
+        let cli = "../target/release/sov-cli";
+        let test_data_path = "../test-data/";
+        let run_cli_cmd = |args: &str| {
+            let args = [
+                "-c",
+                &format!("cd demo/sovereign/demo-rollup/ && ./{} {}", cli, args),
+            ];
+
+            duct::cmd("sh", args).run()
+        };
+
+        info!("setup rpc endpoint");
+        run_cli_cmd("rpc set-url http://127.0.0.1:12345")?;
+
+        info!("import keys");
+        run_cli_cmd(&format!(
+            "keys import --nickname token_deployer --path {}keys/token_deployer_private_key.json",
+            test_data_path
+        ))?;
+
+        info!("create and mint a new token");
+        run_cli_cmd(&format!(
+            "transactions import from-file bank --path {}requests/create_token.json",
+            test_data_path
+        ))?;
+
+        run_cli_cmd(&format!(
+            "transactions import from-file bank --path {}requests/mint.json",
+            test_data_path
+        ))?;
+
+        info!("submit batch with two transactions");
+        run_cli_cmd("rpc submit-batch by-nickname token_deployer")?;
+
+        // TODO: https://github.com/thrumdev/blobs/issues/226
+        info!("waiting for the rollup to process the transactions");
+        std::thread::sleep(std::time::Duration::from_secs(30));
+
+        let response = cmd!("sh", "-c", "curl -s -X POST -H \
+                              \"Content-Type: application/json\" \
+                              -d '{\"jsonrpc\":\"2.0\",\"method\":\"bank_supplyOf\",\
+                              \"params\":[\"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72\"],\
+                              \"id\":1}' http://127.0.0.1:12345").stdout_capture().run()?;
+
+        if let None = String::from_utf8(response.stdout)?.find("\"amount\":4000") {
+            bail!("Tokens not properly minted in the rollup")
+        }
+
+        info!("4000 tokens properly minted in the rollup");
+
+        Ok(())
+    }
+}
+
+impl Drop for Sovereign {
+    // duct::Handle does not implement kill on drop
+    fn drop(&mut self) {
+        info!("Sovereign rollup process is going to be killed");
+        let _ = self.0.kill();
+    }
+}

--- a/xtask/src/zombienet.rs
+++ b/xtask/src/zombienet.rs
@@ -1,0 +1,64 @@
+use crate::{cli::test::ZombienetParams, start_maybe_quiet};
+use duct::cmd;
+use tracing::info;
+
+pub struct Zombienet(duct::Handle);
+
+impl Zombienet {
+    // Try launching the network using zombienet
+    //
+    // The binaries for zombienet and polkadot are expected to be in the PATH,
+    // while polkadot-execute-worker and polkadot-prepare-worker
+    // need to be in the same directory as the polkadot binary.
+    pub fn try_new(params: ZombienetParams) -> anyhow::Result<Self> {
+        info!("Deleting the zombienet folder if it already exists");
+        cmd!("rm", "-r", "zombienet").unchecked().run()?;
+
+        info!("Checking binaries availability");
+        let check_binary = |binary: &'static str, error_msg: &'static str| -> anyhow::Result<()> {
+            if let Err(_) = cmd!("sh", "-c", format!("command -v {}", binary))
+                .stdout_null()
+                .run()
+            {
+                anyhow::bail!(error_msg);
+            }
+            Ok(())
+        };
+
+        check_binary(
+            "zombienet",
+            "'zombienet' is not found in PATH. Install zombienet. \n \
+             Available at https://github.com/paritytech/zombienet",
+        )?;
+
+        check_binary(
+            "polkadot",
+            "'polkadot' is not found in PATH. Install polkadot \n \
+              To obtain, refer to https://github.com/paritytech/polkadot-sdk/tree/master/polkadot#polkadot"
+        )?;
+
+        check_binary(
+            "sugondat-node",
+            "'sugondat-node' is not found in PATH.  \n \
+             cd to 'sugondat/chain' and run 'cargo build --release' and add the result into your PATH."
+        )?;
+
+        info!("Launching zombienet");
+        #[rustfmt::skip]
+        let zombienet_handle = start_maybe_quiet(
+            cmd!("zombienet", "spawn", "-p", "native", "--dir", "zombienet", "testnet.toml"),
+            params.quiet,
+        )?;
+
+        Ok(Self(zombienet_handle))
+    }
+}
+
+impl Drop for Zombienet {
+    // duct::Handle does not implement kill on drop
+    fn drop(&mut self) {
+        // TODO: https://github.com/thrumdev/blobs/issues/228
+        info!("Zombienet process is going to be killed");
+        let _ = self.0.kill();
+    }
+}


### PR DESCRIPTION
The following PR introduces the usage of xtask for scripting tests and handling CI. It includes minimal required components for enabling sovereign rollup testing. Additional features mentioned in new issues are linked within the code and should be addressed as follow up PRs

p.s.
#[rustfmt::skip] is just my preference for avoiding multiple lines in the "cmd!" macro. If you don't agree with it or if it goes against the standard, I can remove it easily
