### PR TITLE
node: remove export-genesis-state alias

### DIFF
--- a/sugondat/chain/node/src/cli.rs
+++ b/sugondat/chain/node/src/cli.rs
@@ -36,7 +36,6 @@ pub enum Subcommand {
     /// Export the genesis head-data of the parachain.
     ///
     /// Head data is the encoded block header.
-    #[command(alias = "export-genesis-state")]
     ExportGenesisHead(cumulus_client_cli::ExportGenesisHeadCommand),
 
     /// Export the genesis wasm of the parachain.


### PR DESCRIPTION
The alias is no longer needed by zombienet after the following issue was solved in version 1.3.92
https://github.com/paritytech/zombienet/issues/1712#issuecomment-1924672880