### PR TITLE
xtask: remove node binary from path

### DIFF
--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -18,6 +18,10 @@ pub mod test {
     use clap::Args;
     #[derive(Debug, Args)]
     pub struct Params {
+        /// If the test is executed in CI
+        #[clap(long, default_value = "false")]
+        pub ci: bool,
+
         #[clap(flatten)]
         pub build: BuildParams,
 

--- a/xtask/src/shim.rs
+++ b/xtask/src/shim.rs
@@ -13,13 +13,13 @@ impl Shim {
         // Wait for the shim to be connected, which indicates that the network is ready
         with_logs(
             "Wait for the network to be ready",
-            cmd!("sugondat-shim", "query", "block", "--wait", "1",).dir("target/release/"),
+            cmd!("sugondat-shim", "query", "block", "--wait", "1"),
         )
         .run()?;
 
         let shim_handle = with_logs(
             "Launching Shim",
-            cmd!("sugondat-shim", "serve", "--submit-dev-alice").dir("target/release/"),
+            cmd!("sugondat-shim", "serve", "--submit-dev-alice"),
         )
         .start()?;
 

--- a/xtask/src/sovereign.rs
+++ b/xtask/src/sovereign.rs
@@ -22,14 +22,11 @@ impl Sovereign {
         let with_logs = create_with_logs(params.log_path.clone());
 
         //TODO: https://github.com/thrumdev/blobs/issues/227
-        #[rustfmt::skip]
         let sovereign_handle = with_logs(
             "Launching sovereign rollup",
-            cmd!(
-                "sh", "-c",
-                "cd demo/sovereign/demo-rollup && ./../target/release/sov-demo-rollup"
-            ),
-        ).start()?;
+            cmd!("sov-demo-rollup").dir("demo/sovereign/demo-rollup/"),
+        )
+        .start()?;
 
         Ok(Self {
             process: sovereign_handle,

--- a/xtask/src/zombienet.rs
+++ b/xtask/src/zombienet.rs
@@ -37,12 +37,6 @@ impl Zombienet {
               To obtain, refer to https://github.com/paritytech/polkadot-sdk/tree/master/polkadot#polkadot"
         )?;
 
-        check_binary(
-            "sugondat-node",
-            "'sugondat-node' is not found in PATH.  \n \
-             cd to 'sugondat/chain' and run 'cargo build --release' and add the result into your PATH."
-        )?;
-
         tracing::info!("Zombienet logs redirected to {}", params.log_path);
         let with_logs = create_with_logs(params.log_path);
 


### PR DESCRIPTION
Zombienet requires the node binary to be in the path.
Until now, it was sourced before calling 'zombienet.sh',
which made things more complex in CI.
Removing the need to source it before and instead
doing it in the test script makes it easier to work with

Implementing this, I understood better how Duct works, and I had to also change how I was executing the shim. Solving #232 it is probable that the way commands are executed will change again