### PR TITLE
node: reinstate `export-genesis-state`.

### DIFF
--- a/ikura/chain/node/src/cli.rs
+++ b/ikura/chain/node/src/cli.rs
@@ -36,6 +36,7 @@ pub enum Subcommand {
     /// Export the genesis head-data of the parachain.
     ///
     /// Head data is the encoded block header.
+    #[clap(alias = "export-genesis-state")]
     ExportGenesisHead(cumulus_client_cli::ExportGenesisHeadCommand),
 
     /// Export the genesis wasm of the parachain.


### PR DESCRIPTION
This is needed because of the lack of binary builds of zombienet
for macOS.

Reverts #229