### PR TITLE
xtask: make testing cwd independent

### DIFF
--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -3,13 +3,13 @@ use duct::cmd;
 
 // TODO: https://github.com/thrumdev/blobs/issues/225
 
-pub fn build(params: BuildParams) -> anyhow::Result<()> {
+pub fn build(project_path: &std::path::Path, params: BuildParams) -> anyhow::Result<()> {
     if params.skip {
         return Ok(());
     }
 
     tracing::info!("Building logs redirected {}", params.log_path);
-    let with_logs = create_with_logs(params.log_path);
+    let with_logs = create_with_logs(project_path, params.log_path);
 
     // `it is advisable to use CARGO environmental variable to get the right cargo`
     // quoted by xtask readme
@@ -27,14 +27,15 @@ pub fn build(params: BuildParams) -> anyhow::Result<()> {
     )
     .run()?;
 
+    let sov_demo_rollup_path = project_path.join("demo/sovereign/demo-rollup/");
     #[rustfmt::skip]
     with_logs(
         "Building sovereign demo-rollup",
         cmd!(
             "sh", "-c",
             format!(
-                "cd demo/sovereign/demo-rollup/ && {} build --release",
-                cargo
+                "cd {}  && {cargo} build --release",
+                sov_demo_rollup_path.to_string_lossy()
             )
         ),
     ).run()?;

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -44,6 +44,9 @@ pub mod test {
         pub skip: bool,
 
         /// Build process stdout and stderr are redirected into this file
+        ///
+        /// Relative paths will be treated as relative to the root project directory
+        /// and not relative to where it is called
         #[arg(
             long = "build-log-path",
             value_name = "log-path",
@@ -56,6 +59,9 @@ pub mod test {
     #[derive(clap::Args, Debug, Clone)]
     pub struct ShimParams {
         /// Shim process stdout and stderr are redirected into this file
+        ///
+        /// Relative paths will be treated as relative to the root project directory
+        /// and not relative to where it is called
         #[arg(long = "shim-log-path", value_name = "log-path", id = "shim.log-path")]
         #[clap(default_value = "test_log/shim.log")]
         pub log_path: String,
@@ -64,6 +70,9 @@ pub mod test {
     #[derive(clap::Args, Debug, Clone)]
     pub struct ZombienetParams {
         /// Zombienet process stdout and stderr are redirected into this file
+        ///
+        /// Relative paths will be treated as relative to the root project directory
+        /// and not relative to where it is called
         #[arg(
             long = "zombienet-log-path",
             value_name = "log-path",
@@ -76,6 +85,9 @@ pub mod test {
     #[derive(clap::Args, Debug, Clone)]
     pub struct SovereignParams {
         /// Sovereign rollup process stdout and stderr are redirected into this file
+        ///
+        /// Relative paths will be treated as relative to the root project directory
+        /// and not relative to where it is called
         #[arg(
             long = "sovereign-log-path",
             value_name = "log-path",

--- a/xtask/src/logging.rs
+++ b/xtask/src/logging.rs
@@ -1,13 +1,22 @@
-use std::io::Write;
 use std::path::Path;
+use std::{io::Write, path::PathBuf};
 use tracing::{info, warn};
 
-fn create_log_file(log_path: &String) -> std::io::Result<()> {
-    if let Some(prefix) = Path::new(&log_path).parent() {
+// If log_path is relative it will be made absolute relative to the project_path
+//
+// The absolute path of where the log file is created is returned
+fn create_log_file(project_path: &Path, log_path: &String) -> std::io::Result<PathBuf> {
+    let mut log_path: PathBuf = Path::new(&log_path).to_path_buf();
+
+    if log_path.is_relative() {
+        log_path = project_path.join(log_path);
+    }
+
+    if let Some(prefix) = log_path.parent() {
         std::fs::create_dir_all(prefix)?;
     }
     std::fs::File::create(&log_path)?;
-    Ok(())
+    Ok(log_path)
 }
 
 // If the log file cannot be created due to any reasons,
@@ -18,6 +27,7 @@ fn create_log_file(log_path: &String) -> std::io::Result<()> {
 // The description will be printed to both stdout and the log file, if possible, while
 // to the expression will be added the redirection of the logs, if possible.
 pub fn create_with_logs(
+    project_path: &Path,
     log_path: String,
 ) -> Box<dyn Fn(&str, duct::Expression) -> duct::Expression> {
     let without_logs = |description: &str, cmd: duct::Expression| -> duct::Expression {
@@ -25,10 +35,13 @@ pub fn create_with_logs(
         cmd
     };
 
-    if let Err(e) = create_log_file(&log_path) {
-        warn!("Impossible redirect to {log_path}, using stdout instead. Error: {e}");
-        return Box::new(without_logs);
-    }
+    let log_path = match create_log_file(project_path, &log_path) {
+        Ok(log_path) => log_path,
+        Err(e) => {
+            warn!("Impossible redirect logs, using stdout instead. Error: {e}");
+            return Box::new(without_logs);
+        }
+    };
 
     let with_logs = move |description: &str, cmd: duct::Expression| -> duct::Expression {
         // The file has just been created
@@ -38,12 +51,13 @@ pub fn create_with_logs(
             .unwrap();
 
         info!("{description}");
+        let log_path = log_path.to_string_lossy();
         let _ = log_file
             .write(format!("{}\n", description).as_bytes())
-            .map_err(|e| warn!("Error writing into {log_path}, error: {e}"));
+            .map_err(|e| warn!("Error writing into {log_path}, error: {e}",));
         let _ = log_file
             .flush()
-            .map_err(|e| warn!("Error writing into {log_path}, error: {e}"));
+            .map_err(|e| warn!("Error writing into {log_path}, error: {e}",));
         cmd.stderr_to_stdout().stdout_file(log_file)
     };
 

--- a/xtask/src/shim.rs
+++ b/xtask/src/shim.rs
@@ -6,7 +6,7 @@ pub struct Shim(duct::Handle);
 
 impl Shim {
     // Try launching the shim, it requires an up an running ikura-node
-    pub fn try_new(params: ShimParams) -> anyhow::Result<Self> {
+    pub fn try_new(project_path: &std::path::Path, params: ShimParams) -> anyhow::Result<Self> {
         check_binary(
             "ikura-shim",
             "'ikura-node' is not found in PATH.  \n \
@@ -14,7 +14,7 @@ impl Shim {
         )?;
 
         tracing::info!("Shim logs redirected to {}", params.log_path);
-        let with_logs = create_with_logs(params.log_path);
+        let with_logs = create_with_logs(project_path, params.log_path);
 
         // Wait for the shim to be connected, which indicates that the network is ready
         with_logs(


### PR DESCRIPTION
The only non-trivial thing in this PR should be how 'log_path' is specified in the CLI. I propose handling it in the following way: if 'log_path' is relative, it will be made absolute relative to the root project_path and not to where the command is actually called. Absolute paths would not been changed

closes #232 