### PR TITLE
xtask: utility to launch zombienet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
+dependencies = [
+ "nix 0.27.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/polkadot-sdk.git?branch=release-polkadot-v1.6.0#61801ce324f18eacb9c29e2f674f0d262a00bd4d"
@@ -6452,6 +6462,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nmt-rs"
 version = "0.1.0"
 source = "git+https://github.com/Sovereign-Labs/nmt-rs.git?rev=627f9622a987db4a0b22dc04107442f4010096fb#627f9622a987db4a0b22dc04107442f4010096fb"
@@ -10200,7 +10221,7 @@ dependencies = [
  "log",
  "netlink-packet-route",
  "netlink-proto",
- "nix",
+ "nix 0.24.3",
  "thiserror",
  "tokio",
 ]
@@ -15614,6 +15635,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ctrlc",
  "duct",
  "tracing",
  "tracing-subscriber 0.3.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,3 +182,4 @@ pallet-ikura-length-fee-adjustment = { path = "ikura/chain/pallets/length-fee-ad
 
 # xtask
 duct = { version = "0.13.7" }
+ctrlc = { version = "3.4.2" }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,3 +15,4 @@ clap = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+ctrlc = { workspace = true }

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -1,4 +1,4 @@
-use crate::{cli::test::BuildParams, logging::create_with_logs};
+use crate::{cli::BuildParams, logging::create_with_logs};
 use duct::cmd;
 
 // TODO: https://github.com/thrumdev/blobs/issues/225

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -10,12 +10,51 @@ pub struct Cli {
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     Test(test::Params),
+    Zombienet(zombienet::Params),
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct ZombienetParams {
+    /// Zombienet process stdout and stderr are redirected into this file
+    ///
+    /// Relative paths will be treated as relative to the root project directory
+    /// and not relative to where it is called
+    #[arg(
+        long = "zombienet-log-path",
+        value_name = "log-path",
+        id = "zombienet.log-path"
+    )]
+    #[clap(default_value = "test_log/zombienet.log")]
+    pub log_path: String,
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct BuildParams {
+    /// Skip building required binaries
+    /// (ikura-node, ikura-shim, sov-demo-rollup and sov-cli)
+    #[clap(default_value = "false")]
+    #[arg(long = "skip-build", value_name = "skip", id = "build.skip")]
+    pub skip: bool,
+
+    /// Build process stdout and stderr are redirected into this file
+    ///
+    /// Relative paths will be treated as relative to the root project directory
+    /// and not relative to where it is called
+    #[arg(
+        long = "build-log-path",
+        value_name = "log-path",
+        id = "build.log-path"
+    )]
+    #[clap(default_value = "test_log/build.log")]
+    pub log_path: String,
 }
 
 pub mod test {
+    use super::{BuildParams, ZombienetParams};
 
     // TODO: https://github.com/thrumdev/blobs/issues/224
     use clap::Args;
+
     #[derive(Debug, Args)]
     pub struct Params {
         /// If the test is executed in CI
@@ -36,27 +75,6 @@ pub mod test {
     }
 
     #[derive(clap::Args, Debug, Clone)]
-    pub struct BuildParams {
-        /// Skip building required binaries
-        /// (ikura-node, ikura-shim, sov-demo-rollup and sov-cli)
-        #[clap(default_value = "false")]
-        #[arg(long = "skip-build", value_name = "skip", id = "build.skip")]
-        pub skip: bool,
-
-        /// Build process stdout and stderr are redirected into this file
-        ///
-        /// Relative paths will be treated as relative to the root project directory
-        /// and not relative to where it is called
-        #[arg(
-            long = "build-log-path",
-            value_name = "log-path",
-            id = "build.log-path"
-        )]
-        #[clap(default_value = "test_log/build.log")]
-        pub log_path: String,
-    }
-
-    #[derive(clap::Args, Debug, Clone)]
     pub struct ShimParams {
         /// Shim process stdout and stderr are redirected into this file
         ///
@@ -64,21 +82,6 @@ pub mod test {
         /// and not relative to where it is called
         #[arg(long = "shim-log-path", value_name = "log-path", id = "shim.log-path")]
         #[clap(default_value = "test_log/shim.log")]
-        pub log_path: String,
-    }
-
-    #[derive(clap::Args, Debug, Clone)]
-    pub struct ZombienetParams {
-        /// Zombienet process stdout and stderr are redirected into this file
-        ///
-        /// Relative paths will be treated as relative to the root project directory
-        /// and not relative to where it is called
-        #[arg(
-            long = "zombienet-log-path",
-            value_name = "log-path",
-            id = "zombienet.log-path"
-        )]
-        #[clap(default_value = "test_log/zombienet.log")]
         pub log_path: String,
     }
 
@@ -95,5 +98,23 @@ pub mod test {
         )]
         #[clap(default_value = "test_log/sovereign.log")]
         pub log_path: String,
+    }
+}
+
+pub mod zombienet {
+    use super::{BuildParams, ZombienetParams};
+    use clap::Args;
+
+    #[derive(Debug, Args)]
+    pub struct Params {
+        /// If the test is executed in CI
+        #[clap(long, default_value = "false")]
+        pub ci: bool,
+
+        #[clap(flatten)]
+        pub build: BuildParams,
+
+        #[clap(flatten)]
+        pub zombienet: ZombienetParams,
     }
 }

--- a/xtask/src/zombienet.rs
+++ b/xtask/src/zombienet.rs
@@ -1,4 +1,4 @@
-use crate::{check_binary, cli::test::ZombienetParams, logging::create_with_logs};
+use crate::{check_binary, cli::ZombienetParams, logging::create_with_logs};
 use duct::cmd;
 use std::path::Path;
 use tracing::info;


### PR DESCRIPTION
Adds a new command `cargo xtask zombienet` to launch polkadot validator set and an ikura-node collator.

Useful to test changes.

Note that potentially this tool will evolve into one that launches not only zombienet but also shim. But it's for the future.