### PR TITLE
xtask: add no_infer_bin_path flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
       - name: cargo test
         run: cargo test --verbose --all
       - name: cargo xtask test
-        run: cargo xtask test --ci
+        run: cargo xtask test

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -57,9 +57,11 @@ pub mod test {
 
     #[derive(Debug, Args)]
     pub struct Params {
-        /// If the test is executed in CI
+        /// By default, binary paths are extracted using the `cargo metadata` command under the key `target_directory`.
+        ///
+        /// To disable this behavior and manually add all binaries to the path, you need to specify this flag
         #[clap(long, default_value = "false")]
-        pub ci: bool,
+        pub no_infer_bin_path: bool,
 
         #[clap(flatten)]
         pub build: BuildParams,


### PR DESCRIPTION
remove the ci flag and set the default behavior to add binaries to the path and CONSTANTS_MANIFEST to environment variables