### PR TITLE
ci: print log on test failure and clean cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,14 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
+      - name: cargo clean cache
+        run: cargo install cargo-cache --no-default-features --features ci-autoclean cargo-cache && cargo-cache
       - name: cargo build
         run: cargo build --verbose --all
       - name: cargo test
         run: cargo test --verbose --all
       - name: cargo xtask test
         run: cargo xtask test
+      - name: print logs if tests fail
+        run: cat test_log/*.log
+        if: failure()


### PR DESCRIPTION
cleaning cargo cache between runs is necessary to avoid using binaries from different prs. The main function of cargo-cache does is [removing git repos that have been checked out
](https://users.rust-lang.org/t/cargo-cache-0-3-4-faster-cargo-home-caching-on-ci/36635)

`cargo install cargo-cache --no-default-features --features ci-autoclean` should only be done in the gha docker file. Currently, it is also being executed in the GitHub workflow because the runner needs to be manually updated to make these changes. The command will be removed from the workflow in a follow-up PR once the runner is updated
