### PR TITLE
shim/rollkit: downgrade go-da to 0.2.0

### DIFF
--- a/ikura/shim/proto/da.proto
+++ b/ikura/shim/proto/da.proto
@@ -1,22 +1,19 @@
 // taken as is from:
-// https://github.com/rollkit/go-da/blob/4538294d1704417d0b80273e6437ba1de5548e8a/da.go
+// https://github.com/rollkit/go-da/blob/82f52969243cfa2bd7e4b1bd78bff48ed9cfffe6/proto/da/da.proto
 
 syntax = "proto3";
 package da;
 
 // DAService is the protobuf service definition for interaction with Data Availability layers.
 service DAService {
-	// MaxBlobSize returns the maximum blob size
-	rpc MaxBlobSize(MaxBlobSizeRequest) returns (MaxBlobSizeResponse) {}
+    // MaxBlobSize returns the maximum blob size
+    rpc MaxBlobSize(MaxBlobSizeRequest) returns (MaxBlobSizeResponse) {}
 
 	// Get returns Blob for each given ID, or an error.
 	rpc Get(GetRequest) returns (GetResponse) {}
 
 	// GetIDs returns IDs of all Blobs located in DA at given height.
 	rpc GetIDs(GetIDsRequest) returns (GetIDsResponse) {}
-
-	// GetProofs returns inclusion Proofs for all Blobs located in DA at given height.
-	rpc GetProofs(GetProofsRequest) returns (GetProofsResponse) {}
 
 	// Commit creates a Commitment for each given Blob.
 	rpc Commit(CommitRequest) returns (CommitResponse) {}
@@ -26,11 +23,6 @@ service DAService {
 
 	// Validate validates Commitments against corresponding Proofs. This should be possible without retrieving Blob.
 	rpc Validate(ValidateRequest) returns (ValidateResponse) {}
-}
-
-// Namespace is the location for the blob to be submitted to, if supported by the DA layer.
-message Namespace {
-	bytes value = 1;
 }
 
 // Blob is the data submitted/received from DA interface.
@@ -59,13 +51,12 @@ message MaxBlobSizeRequest {
 
 // MaxBlobSizeResponse is the response type for the MaxBlobSize rpc method.
 message MaxBlobSizeResponse {
-	uint64 max_blob_size = 1;
+    uint64 max_blob_size = 1;
 }
 
 // GetRequest is the request type for the Get rpc method.
 message GetRequest {
 	repeated ID ids = 1;
-	Namespace namespace = 2;
 }
 
 // GetResponse is the response type for the Get rpc method.
@@ -76,7 +67,6 @@ message GetResponse {
 // GetIDsRequest is the request type for the GetIDs rpc method.
 message GetIDsRequest {
 	uint64 height = 1;
-	Namespace namespace = 2;
 }
 
 // GetIDsResponse is the response type for the GetIDs rpc method.
@@ -84,21 +74,9 @@ message GetIDsResponse {
 	repeated ID ids = 1;
 }
 
-// GetProofsRequest is the request type for the GetProofs rpc method.
-message GetProofsRequest {
-	repeated ID ids = 1;
-	Namespace namespace = 2;
-}
-
-// GetProofsResponse is the response type for the GetProofs rpc method.
-message GetProofsResponse {
-	repeated Proof proofs = 1;
-}
-
 // CommitRequest is the request type for the Commit rpc method.
 message CommitRequest {
 	repeated Blob blobs = 1;
-	Namespace namespace = 2;
 }
 
 // CommitResponse is the response type for the Commit rpc method.
@@ -110,19 +88,18 @@ message CommitResponse {
 message SubmitRequest {
 	repeated Blob blobs = 1;
 	double gas_price = 2;
-	Namespace namespace = 3;
 }
 
 // SubmitResponse is the response type for the Submit rpc method.
 message SubmitResponse {
 	repeated ID ids = 1;
+	repeated Proof proofs = 2;
 }
 
 // ValidateRequest is the request type for the Validate rpc method.
 message ValidateRequest {
 	repeated ID ids = 1;
 	repeated Proof proofs = 2;
-	Namespace namespace = 3;
 }
 
 // ValidateResponse is the response type for the Validate rpc method.


### PR DESCRIPTION
the version that was introduced in #260
(997046d926170d0bcf5e2824d5670c0a5fb85a2f) was using
the latest version of go-da (0.4.0) gRPC service decl.

However, the latest version of rollkit on which the gm
demo was based off, was using 0.2.0. That was causing
occasional problems.

So I went ahead and downgraded it. Now, it seems to
workfine (with exception of #259).

Closes #258.