### PR TITLE
shim: parallel submission

### DIFF
--- a/ikura/shim/src/cmd/query/submit.rs
+++ b/ikura/shim/src/cmd/query/submit.rs
@@ -20,7 +20,11 @@ pub async fn run(params: Params) -> anyhow::Result<()> {
     let namespace = read_namespace(&namespace)?;
     let client = connect_rpc(rpc).await?;
     tracing::info!("submitting blob to namespace {}", namespace);
-    let (block_hash, _) = client.submit_blob(blob, namespace, key).await?;
+    let nonce = client.get_last_nonce(&key).await?;
+    let blob_extrinsic = client
+        .make_blob_extrinsic(blob, namespace, &key, nonce)
+        .await?;
+    let (block_hash, _) = client.submit_blob(&blob_extrinsic).await?;
     tracing::info!("submitted blob to block hash 0x{}", hex::encode(block_hash));
     Ok(())
 }

--- a/ikura/shim/src/dock/rpc_error.rs
+++ b/ikura/shim/src/dock/rpc_error.rs
@@ -8,6 +8,25 @@ pub fn no_signing_key() -> ErrorObjectOwned {
     )
 }
 
+pub fn nonce_obtain_error(e: anyhow::Error) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(
+        jsonrpsee::types::error::INTERNAL_ERROR_CODE,
+        format!("Internal Error: failed to obtain nonce: {:?}", e),
+        None::<()>,
+    )
+}
+
+pub fn submit_extrinsic_error(e: anyhow::Error) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(
+        jsonrpsee::types::error::INTERNAL_ERROR_CODE,
+        format!(
+            "Internal Error: failed to create a submit blob extrinsic: {:?}",
+            e
+        ),
+        None::<()>,
+    )
+}
+
 pub fn submission_error(e: anyhow::Error) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(
         jsonrpsee::types::error::INTERNAL_ERROR_CODE,


### PR DESCRIPTION
rollkit demo submits a lot of blobs. In my testing I saw
dozens of blobs submitted at the same time. Ofc submitting
those serially won't cut it, esp. so if waiting until
finalization.

This changeset solves the problem by splitting the signing
part, which is still serial, and the submission, which is
now parallel.

As a drive-by fix, all the errors for rollkit are now
encapsulated into an enum.

Closes #259