### PR TITLE
cli: add a note about submission key

### DIFF
--- a/ikura/shim/proto/da.proto
+++ b/ikura/shim/proto/da.proto
@@ -1,22 +1,19 @@
 // taken as is from:
-// https://github.com/rollkit/go-da/blob/4538294d1704417d0b80273e6437ba1de5548e8a/da.go
+// https://github.com/rollkit/go-da/blob/82f52969243cfa2bd7e4b1bd78bff48ed9cfffe6/proto/da/da.proto
 
 syntax = "proto3";
 package da;
 
 // DAService is the protobuf service definition for interaction with Data Availability layers.
 service DAService {
-	// MaxBlobSize returns the maximum blob size
-	rpc MaxBlobSize(MaxBlobSizeRequest) returns (MaxBlobSizeResponse) {}
+    // MaxBlobSize returns the maximum blob size
+    rpc MaxBlobSize(MaxBlobSizeRequest) returns (MaxBlobSizeResponse) {}
 
 	// Get returns Blob for each given ID, or an error.
 	rpc Get(GetRequest) returns (GetResponse) {}
 
 	// GetIDs returns IDs of all Blobs located in DA at given height.
 	rpc GetIDs(GetIDsRequest) returns (GetIDsResponse) {}
-
-	// GetProofs returns inclusion Proofs for all Blobs located in DA at given height.
-	rpc GetProofs(GetProofsRequest) returns (GetProofsResponse) {}
 
 	// Commit creates a Commitment for each given Blob.
 	rpc Commit(CommitRequest) returns (CommitResponse) {}
@@ -26,11 +23,6 @@ service DAService {
 
 	// Validate validates Commitments against corresponding Proofs. This should be possible without retrieving Blob.
 	rpc Validate(ValidateRequest) returns (ValidateResponse) {}
-}
-
-// Namespace is the location for the blob to be submitted to, if supported by the DA layer.
-message Namespace {
-	bytes value = 1;
 }
 
 // Blob is the data submitted/received from DA interface.
@@ -59,13 +51,12 @@ message MaxBlobSizeRequest {
 
 // MaxBlobSizeResponse is the response type for the MaxBlobSize rpc method.
 message MaxBlobSizeResponse {
-	uint64 max_blob_size = 1;
+    uint64 max_blob_size = 1;
 }
 
 // GetRequest is the request type for the Get rpc method.
 message GetRequest {
 	repeated ID ids = 1;
-	Namespace namespace = 2;
 }
 
 // GetResponse is the response type for the Get rpc method.
@@ -76,7 +67,6 @@ message GetResponse {
 // GetIDsRequest is the request type for the GetIDs rpc method.
 message GetIDsRequest {
 	uint64 height = 1;
-	Namespace namespace = 2;
 }
 
 // GetIDsResponse is the response type for the GetIDs rpc method.
@@ -84,21 +74,9 @@ message GetIDsResponse {
 	repeated ID ids = 1;
 }
 
-// GetProofsRequest is the request type for the GetProofs rpc method.
-message GetProofsRequest {
-	repeated ID ids = 1;
-	Namespace namespace = 2;
-}
-
-// GetProofsResponse is the response type for the GetProofs rpc method.
-message GetProofsResponse {
-	repeated Proof proofs = 1;
-}
-
 // CommitRequest is the request type for the Commit rpc method.
 message CommitRequest {
 	repeated Blob blobs = 1;
-	Namespace namespace = 2;
 }
 
 // CommitResponse is the response type for the Commit rpc method.
@@ -110,19 +88,18 @@ message CommitResponse {
 message SubmitRequest {
 	repeated Blob blobs = 1;
 	double gas_price = 2;
-	Namespace namespace = 3;
 }
 
 // SubmitResponse is the response type for the Submit rpc method.
 message SubmitResponse {
 	repeated ID ids = 1;
+	repeated Proof proofs = 2;
 }
 
 // ValidateRequest is the request type for the Validate rpc method.
 message ValidateRequest {
 	repeated ID ids = 1;
 	repeated Proof proofs = 2;
-	Namespace namespace = 3;
 }
 
 // ValidateResponse is the response type for the Validate rpc method.

--- a/ikura/shim/src/cli.rs
+++ b/ikura/shim/src/cli.rs
@@ -48,6 +48,9 @@ pub struct KeyManagementParams {
     ///
     /// This key is enabled when running ikura-node in the local development mode.
     ///
+    /// NOTE: Submitting blobs is assumed to have complete control over the signing key. In case
+    /// there is another process running with the same key, it may cause error during submission.
+    ///
     /// Cannot be used in conjunction with the `--submit-private-key` flag.
     #[arg(long)]
     pub submit_dev_alice: bool,
@@ -56,6 +59,9 @@ pub struct KeyManagementParams {
     ///
     /// The keyfile should be 32 bytes of unencrypted, hex-encoded sr25519
     /// seed material.
+    ///
+    /// NOTE: Submitting blobs is assumed to have complete control over the signing key. In case
+    /// there is another process running with the same key, it may cause error during submission.
     ///
     /// Cannot be used in conjunction with the `--submit-dev-alice` flag.
     #[arg(long, value_name = "PATH")]

--- a/ikura/shim/src/cmd/query/submit.rs
+++ b/ikura/shim/src/cmd/query/submit.rs
@@ -20,7 +20,11 @@ pub async fn run(params: Params) -> anyhow::Result<()> {
     let namespace = read_namespace(&namespace)?;
     let client = connect_rpc(rpc).await?;
     tracing::info!("submitting blob to namespace {}", namespace);
-    let (block_hash, _) = client.submit_blob(blob, namespace, key).await?;
+    let nonce = client.get_last_nonce(&key).await?;
+    let blob_extrinsic = client
+        .make_blob_extrinsic(blob, namespace, &key, nonce)
+        .await?;
+    let (block_hash, _) = client.submit_blob(&blob_extrinsic).await?;
     tracing::info!("submitted blob to block hash 0x{}", hex::encode(block_hash));
     Ok(())
 }

--- a/ikura/shim/src/dock/rpc_error.rs
+++ b/ikura/shim/src/dock/rpc_error.rs
@@ -8,6 +8,25 @@ pub fn no_signing_key() -> ErrorObjectOwned {
     )
 }
 
+pub fn nonce_obtain_error(e: anyhow::Error) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(
+        jsonrpsee::types::error::INTERNAL_ERROR_CODE,
+        format!("Internal Error: failed to obtain nonce: {:?}", e),
+        None::<()>,
+    )
+}
+
+pub fn submit_extrinsic_error(e: anyhow::Error) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(
+        jsonrpsee::types::error::INTERNAL_ERROR_CODE,
+        format!(
+            "Internal Error: failed to create a submit blob extrinsic: {:?}",
+            e
+        ),
+        None::<()>,
+    )
+}
+
 pub fn submission_error(e: anyhow::Error) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(
         jsonrpsee::types::error::INTERNAL_ERROR_CODE,


### PR DESCRIPTION
nonce handling is assumed to be perfomed only by a single process
in the network. Otherwise, there may be two processes that signed
an extrinsic with the same nonce. This may lead to rejection
of one of the extrinsics.