### PR TITLE
ci: clarify the name of a print logs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,6 @@ jobs:
         run: cargo test --verbose --all
       - name: cargo xtask test
         run: cargo xtask test
-      - name: print logs
+      - name: print logs (on failure)
         run: cat test_log/*.log
         if: failure()


### PR DESCRIPTION
Specifically, that it runs only on failure
